### PR TITLE
Bump version to 0.7.3 and add instanceRbacDisabled option

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qoretechnologies/reqraft",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "description": "ReQraft is a collection of React components and hooks that are used across Qore Technologies' products made using the ReQore component library from Qore.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/providers/ReqraftProvider.tsx
+++ b/src/providers/ReqraftProvider.tsx
@@ -19,6 +19,7 @@ export interface IReqraftProviderProps extends IReqraftContext {
 export interface IReqraftOptions {
   instance?: string;
   instanceToken: string;
+  instanceRbacDisabled?: boolean;
   instanceUnauthorizedRedirect?: IReqraftFetchConfig['unauthorizedRedirect'];
 }
 
@@ -26,6 +27,7 @@ export const initializeReqraft = (options: IReqraftOptions) => {
   setupFetch({
     instance: options.instance,
     instanceToken: options.instanceToken,
+    instanceRbacDisabled: options.instanceRbacDisabled,
     unauthorizedRedirect: options.instanceUnauthorizedRedirect,
   });
 

--- a/src/utils/fetch.ts
+++ b/src/utils/fetch.ts
@@ -4,6 +4,7 @@ import { ReqraftQueryClient } from '../providers/ReqraftProvider';
 export interface IReqraftFetchConfig {
   instance: string;
   instanceToken: string;
+  instanceRbacDisabled?: boolean;
   unauthorizedRedirect?: (pathname: string) => string;
 }
 
@@ -26,10 +27,12 @@ const CACHE_EXPIRATION_TIME = 5 * 60 * 1000; // 5 minutes
 export const setupFetch = ({
   instance,
   instanceToken,
+  instanceRbacDisabled,
   unauthorizedRedirect,
 }: IReqraftFetchConfig) => {
   fetchConfig.instance = instance;
   fetchConfig.instanceToken = instanceToken;
+  fetchConfig.instanceRbacDisabled = instanceRbacDisabled;
 
   if (unauthorizedRedirect) {
     fetchConfig.unauthorizedRedirect = unauthorizedRedirect;
@@ -41,7 +44,7 @@ async function doFetchData(
   method = 'GET',
   body?: { [key: string]: any }
 ): Promise<Response> {
-  if (!fetchConfig.instanceToken) {
+  if (!fetchConfig.instanceToken && !fetchConfig.instanceRbacDisabled) {
     return new Response(JSON.stringify({}), {
       status: 401,
       statusText: 'Unauthorized',
@@ -52,7 +55,9 @@ async function doFetchData(
     method,
     headers: {
       'Content-Type': 'application/json',
-      Authorization: `Bearer ${fetchConfig.instanceToken}`,
+      Authorization: fetchConfig.instanceRbacDisabled
+        ? undefined
+        : `Bearer ${fetchConfig.instanceToken}`,
     },
     body: JSON.stringify(body),
   }).catch((error) => {


### PR DESCRIPTION
Update the package version and introduce the `instanceRbacDisabled` option to enhance the configuration capabilities of the `IReqraftOptions` interface. Adjustments made to the fetch logic accommodate this new option.