### PR TITLE
Add noApiPrefix option for flexible API endpoint handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qoretechnologies/reqraft",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "ReQraft is a collection of React components and hooks that are used across Qore Technologies' products made using the ReQore component library from Qore.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/hooks/useFetch/useFetch.tsx
+++ b/src/hooks/useFetch/useFetch.tsx
@@ -24,6 +24,7 @@ export function useFetch<T>({
   cache,
   defaultData,
   loadOnMount,
+  noApiPrefix,
 }: IReqraftUseFetchOptions<T>) {
   const query = useContextSelector(FetchContext, (context) => {
     switch (method) {
@@ -54,7 +55,7 @@ export function useFetch<T>({
       setLoading(true);
 
       const _body = mergeBodies ? { ...body, ...customBody } : customBody || body;
-      const response = await query<T>({ url, body: _body, cache });
+      const response = await query<T>({ url, body: _body, cache, noApiPrefix });
 
       setLoading(false);
 
@@ -69,7 +70,7 @@ export function useFetch<T>({
 
       setResponse(response.response);
     },
-    [JSON.stringify(body), method, url, cache]
+    [JSON.stringify(body), method, url, cache, noApiPrefix]
   );
 
   useEffectOnce(() => {

--- a/src/utils/fetch.ts
+++ b/src/utils/fetch.ts
@@ -42,7 +42,8 @@ export const setupFetch = ({
 async function doFetchData(
   url: string,
   method = 'GET',
-  body?: { [key: string]: any }
+  body?: { [key: string]: any },
+  noApiPrefix = false
 ): Promise<Response> {
   // We do not check for token because Qorus now handles auth automatically via cookies
   // token is only supplied in a dev environment
@@ -54,7 +55,7 @@ async function doFetchData(
     headers['Authorization'] = `Bearer ${fetchConfig.instanceToken}`;
   }
 
-  return fetch(`${fetchConfig.instance}api/latest/${url}`, {
+  return fetch(`${fetchConfig.instance}${noApiPrefix ? '' : 'api/latest/'}${url}`, {
     method,
     headers,
     body: JSON.stringify(body),
@@ -73,6 +74,7 @@ export interface IReqraftQueryConfig {
   body?: Record<string | number, any>;
   cache?: boolean;
   queryClient?: QueryClient;
+  noApiPrefix?: boolean;
 }
 
 export async function query<T>({
@@ -81,6 +83,7 @@ export async function query<T>({
   body,
   cache = true,
   queryClient = ReqraftQueryClient,
+  noApiPrefix = false,
 }: IReqraftQueryConfig): Promise<IReqraftFetchResponse<T>> {
   const shouldCache = method === 'DELETE' || method === 'POST' ? false : cache;
   const cacheKey = `${url}:${method}:${JSON.stringify(body || {})}`;
@@ -88,7 +91,7 @@ export async function query<T>({
   const requestData = await queryClient.fetchQuery({
     queryKey: [cacheKey],
     queryFn: async () => {
-      const response = await doFetchData(url, method, body);
+      const response = await doFetchData(url, method, body, noApiPrefix);
 
       if (response.status === 401 && fetchConfig.unauthorizedRedirect) {
         window.location.href = fetchConfig.unauthorizedRedirect(window.location);


### PR DESCRIPTION
Introduce a `noApiPrefix` option to fetch functions, allowing for more flexible handling of API endpoints. Update the version to 0.8.1 to reflect these changes.