### PR TITLE
feat: detailed onValidityChange & export validation utilities

### DIFF
--- a/__tests__/validation.test.ts
+++ b/__tests__/validation.test.ts
@@ -657,3 +657,99 @@ describe('hasAllDependenciesFullfilled', () => {
     expect(hasAllDependenciesFullfilled([['parent', 'other']], options, schema)).toBe(true);
   });
 });
+
+// ─── exported validation functions ────────────────────────────────────────────
+
+describe('validation module exports all public functions', () => {
+  it('exports validateField as a function', () => {
+    expect(typeof validateField).toBe('function');
+  });
+
+  it('exports validateFieldWithResult as a function', () => {
+    expect(typeof validateFieldWithResult).toBe('function');
+  });
+
+  it('exports isValueSet as a function', () => {
+    expect(typeof isValueSet).toBe('function');
+  });
+
+  it('exports getTypeFromValue as a function', () => {
+    expect(typeof getTypeFromValue).toBe('function');
+  });
+
+  it('exports maybeParseYaml as a function', () => {
+    expect(typeof maybeParseYaml).toBe('function');
+  });
+
+  it('exports hasAllDependenciesFullfilled as a function', () => {
+    expect(typeof hasAllDependenciesFullfilled).toBe('function');
+  });
+
+  it('exports validateOptionWithRequiredGroups as a function', () => {
+    expect(typeof validateOptionWithRequiredGroups).toBe('function');
+  });
+});
+
+// ─── validateFieldWithResult detailed output ──────────────────────────────────
+
+describe('validateFieldWithResult returns detailed IValidationResult', () => {
+  it('returns isValid: true with empty reasons for valid field', () => {
+    const result = validateFieldWithResult('string', 'hello');
+    expect(result).toEqual({
+      isValid: true,
+      reasons: [],
+    });
+  });
+
+  it('returns isValid: false with reason for invalid required string', () => {
+    const result = validateFieldWithResult('string', '', { has_to_have_value: true });
+    expect(result.isValid).toBe(false);
+    expect(result.reason).toBeDefined();
+    expect(result.reasons.length).toBeGreaterThan(0);
+  });
+
+  it('returns isValid: false with reason for invalid number', () => {
+    const result = validateFieldWithResult('number', 'not-a-number');
+    expect(result.isValid).toBe(false);
+    expect(result.reason).toBeDefined();
+    expect(result.reasons).toContain(result.reason);
+  });
+
+  it('returns isValid: false with reason for invalid int', () => {
+    const result = validateFieldWithResult('int', 3.14);
+    expect(result.isValid).toBe(false);
+    expect(result.reason).toBeDefined();
+  });
+
+  it('returns isValid: false with reason for empty required boolean', () => {
+    const result = validateFieldWithResult('boolean', undefined, { has_to_have_value: true });
+    expect(result.isValid).toBe(false);
+    expect(result.reason).toBeDefined();
+  });
+
+  it('returns isValid: false with reason for invalid cron', () => {
+    const result = validateFieldWithResult('cron', 'not-a-cron');
+    expect(result.isValid).toBe(false);
+    expect(result.reason).toBeDefined();
+  });
+
+  it('returns isValid: false with reason for invalid date', () => {
+    const result = validateFieldWithResult('date', 'not-a-date');
+    expect(result.isValid).toBe(false);
+    expect(result.reason).toBeDefined();
+  });
+
+  it('returns isValid: false with reasons for invalid hash with arg_schema', () => {
+    const result = validateFieldWithResult('hash', { nested: 'value' }, {
+      arg_schema: {
+        requiredProp: {
+          type: 'string',
+          ui_type: 'string',
+          required: true,
+        },
+      },
+    });
+    expect(result.isValid).toBe(false);
+    expect(result.reasons.length).toBeGreaterThan(0);
+  });
+});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qoretechnologies/reqraft",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "ReQraft is a collection of React components and hooks that are used across Qore Technologies' products made using the ReQore component library from Qore.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/components/form/engine/FormEngine.stories.tsx
+++ b/src/components/form/engine/FormEngine.stories.tsx
@@ -1119,23 +1119,21 @@ export const OnValidityChange: Story = {
 
     // onValidityChange should have been called with false and detailed data
     await waitFor(() => {
-      expect(args.onValidityChange).toHaveBeenCalledWith(
-        false,
-        expect.objectContaining({
-          isValid: false,
-          fields: expect.any(Array),
-          invalidFields: expect.arrayContaining([
-            expect.objectContaining({
-              fieldName: 'requiredField',
-              validation: expect.objectContaining({
-                isValid: false,
-                reason: expect.any(String),
-                reasons: expect.any(Array),
-              }),
-            }),
-          ]),
-        })
-      );
+      expect(args.onValidityChange).toHaveBeenCalled();
+
+      const calls = (args.onValidityChange as ReturnType<typeof fn>).mock.calls;
+      const [isValid, data] = calls[calls.length - 1];
+
+      expect(isValid).toBe(false);
+      expect(data.isValid).toBe(false);
+      expect(Array.isArray(data.fields)).toBe(true);
+      expect(data.invalidFields.length).toBe(1);
+
+      const invalidField = data.invalidFields[0];
+      expect(invalidField.fieldName).toBe('requiredField');
+      expect(invalidField.validation.isValid).toBe(false);
+      expect(typeof invalidField.validation.reason).toBe('string');
+      expect(Array.isArray(invalidField.validation.reasons)).toBe(true);
     });
 
     // Type a value into the required field to make the form valid
@@ -1150,15 +1148,14 @@ export const OnValidityChange: Story = {
       expect(canvas.getByTestId('validity-invalid-count').textContent).toBe('0');
     });
 
-    // onValidityChange should have been called with true
+    // onValidityChange should have been called with true and no invalid fields
     await waitFor(() => {
-      expect(args.onValidityChange).toHaveBeenCalledWith(
-        true,
-        expect.objectContaining({
-          isValid: true,
-          invalidFields: [],
-        })
-      );
+      const calls = (args.onValidityChange as ReturnType<typeof fn>).mock.calls;
+      const [isValid, data] = calls[calls.length - 1];
+
+      expect(isValid).toBe(true);
+      expect(data.isValid).toBe(true);
+      expect(data.invalidFields).toHaveLength(0);
     });
   },
 };

--- a/src/components/form/engine/FormEngine.stories.tsx
+++ b/src/components/form/engine/FormEngine.stories.tsx
@@ -1137,7 +1137,7 @@ export const OnValidityChange: Story = {
     });
 
     // Type a value into the required field to make the form valid
-    const requiredInput = document.querySelector('.system-option .reqore-input') as HTMLInputElement;
+    const requiredInput = document.querySelectorAll('.system-option .reqore-textarea')[0] as HTMLTextAreaElement;
     await fireEvent.change(requiredInput, { target: { value: 'hello' } });
 
     await sleep(300);

--- a/src/components/form/engine/FormEngine.stories.tsx
+++ b/src/components/form/engine/FormEngine.stories.tsx
@@ -1137,7 +1137,7 @@ export const OnValidityChange: Story = {
     });
 
     // Type a value into the required field to make the form valid
-    const requiredInput = canvas.getByDisplayValue('');
+    const requiredInput = document.querySelector('.system-option .reqore-input') as HTMLInputElement;
     await fireEvent.change(requiredInput, { target: { value: 'hello' } });
 
     await sleep(300);

--- a/src/components/form/engine/FormEngine.stories.tsx
+++ b/src/components/form/engine/FormEngine.stories.tsx
@@ -14,7 +14,7 @@ import {
   _testsWaitForTextToNotExist,
   sleep,
 } from '../../../stories/Tests/utils';
-import { FormEngine, IFormEngineProps, IOptionsSchema } from './FormEngine';
+import { FormEngine, IFormEngineProps, IFormValidityData, IOptionsSchema } from './FormEngine';
 
 // ─── schema data ──────────────────────────────────────────────────────────────
 
@@ -1046,5 +1046,119 @@ export const AllowedValuesOptionWithTemplateValueShowsWarning: Story = {
     await _testsWaitForText(
       'This field has pre-defined allowed values, make sure the template you select is compatible with those'
     );
+  },
+};
+
+export const OnValidityChange: Story = {
+  args: {
+    options: {
+      requiredField: {
+        type: 'string',
+        ui_type: 'string',
+        display_name: 'Required Field',
+        required: true,
+        preselected: true,
+      },
+      optionalField: {
+        type: 'number',
+        ui_type: 'number',
+        display_name: 'Optional Field',
+        preselected: true,
+      },
+    },
+    value: {},
+  },
+  render: ({ value, onChange, onValidityChange, ...rest }: IFormEngineProps) => {
+    const [val, setValue] = useState(value);
+    const [validityData, setValidityData] = useState<IFormValidityData | null>(null);
+
+    return (
+      <>
+        <FormEngine
+          {...rest}
+          value={val}
+          onChange={(_n, v, m) => {
+            setValue(v);
+            onChange?.(_n, v, m);
+          }}
+          onValidityChange={(isValid, data) => {
+            setValidityData(data);
+            onValidityChange?.(isValid, data);
+          }}
+        />
+        {validityData && (
+          <div data-testid='validity-output'>
+            <span data-testid='validity-is-valid'>{String(validityData.isValid)}</span>
+            <span data-testid='validity-total-fields'>{validityData.fields.length}</span>
+            <span data-testid='validity-invalid-count'>{validityData.invalidFields.length}</span>
+            {validityData.invalidFields.map((f) => (
+              <span key={f.fieldName} data-testid={`invalid-field-${f.fieldName}`}>
+                {f.validation.reason}
+              </span>
+            ))}
+          </div>
+        )}
+      </>
+    );
+  },
+  play: async ({ canvasElement, args }) => {
+    const canvas = within(canvasElement);
+
+    // Wait for the form to render and validity to be reported
+    await waitFor(
+      () => expect(canvas.getByTestId('validity-output')).toBeInTheDocument(),
+      { timeout: 10000 }
+    );
+
+    // The form should be invalid initially because requiredField is empty
+    await waitFor(() => {
+      expect(canvas.getByTestId('validity-is-valid').textContent).toBe('false');
+      expect(canvas.getByTestId('validity-invalid-count').textContent).toBe('1');
+      expect(canvas.getByTestId('invalid-field-requiredField')).toBeInTheDocument();
+    });
+
+    // onValidityChange should have been called with false and detailed data
+    await waitFor(() => {
+      expect(args.onValidityChange).toHaveBeenCalledWith(
+        false,
+        expect.objectContaining({
+          isValid: false,
+          fields: expect.any(Array),
+          invalidFields: expect.arrayContaining([
+            expect.objectContaining({
+              fieldName: 'requiredField',
+              validation: expect.objectContaining({
+                isValid: false,
+                reason: expect.any(String),
+                reasons: expect.any(Array),
+              }),
+            }),
+          ]),
+        })
+      );
+    });
+
+    // Type a value into the required field to make the form valid
+    const requiredInput = canvas.getByDisplayValue('');
+    await fireEvent.change(requiredInput, { target: { value: 'hello' } });
+
+    await sleep(300);
+
+    // Now the form should be valid
+    await waitFor(() => {
+      expect(canvas.getByTestId('validity-is-valid').textContent).toBe('true');
+      expect(canvas.getByTestId('validity-invalid-count').textContent).toBe('0');
+    });
+
+    // onValidityChange should have been called with true
+    await waitFor(() => {
+      expect(args.onValidityChange).toHaveBeenCalledWith(
+        true,
+        expect.objectContaining({
+          isValid: true,
+          invalidFields: [],
+        })
+      );
+    });
   },
 };

--- a/src/components/form/engine/FormEngine.tsx
+++ b/src/components/form/engine/FormEngine.tsx
@@ -38,7 +38,12 @@ import { useDebounce, useUpdateEffect } from 'react-use';
 import { createContext } from 'use-context-selector';
 import { getDefaultValue, insertAtIndex, richtextToString } from '../../../helpers/common';
 import { getRequiredOptionMessage } from '../../../helpers/options';
-import { hasAllDependenciesFullfilled, validateField } from '../../../helpers/validations';
+import {
+  IValidationResult,
+  hasAllDependenciesFullfilled,
+  validateField,
+  validateFieldWithResult,
+} from '../../../helpers/validations';
 import { useQorusTypes } from '../../../hooks/useQorusTypes';
 import { useTemplates } from '../../../hooks/useTemplates';
 import { Description } from '../../Description';
@@ -64,6 +69,19 @@ export interface IOptionsSchema extends IQorusFormSchema {}
 export interface IOperator extends IQorusFormOperator {}
 export interface IOperatorsSchema extends IQorusFormOperatorsSchema {}
 export interface IOptionsOnChangeMeta extends IQorusFormFieldOnChangeMeta {}
+
+export interface IFormFieldValidityData {
+  fieldName: string;
+  type: TQorusType;
+  value: any;
+  validation: IValidationResult;
+}
+
+export interface IFormValidityData {
+  isValid: boolean;
+  fields: IFormFieldValidityData[];
+  invalidFields: IFormFieldValidityData[];
+}
 
 const NegativeColorEffect: any = {
   gradient: {
@@ -276,7 +294,7 @@ export interface IFormEngineProps extends Omit<IReqoreCollectionProps, 'onChange
   templateFieldProps?: Partial<ITemplateFieldProps>;
   showTypeToggle?: boolean;
   compact?: boolean;
-  onValidityChange?: (isValid: boolean) => void;
+  onValidityChange?: (isValid: boolean, data: IFormValidityData) => void;
 }
 
 export const FormEngine = ({
@@ -663,36 +681,64 @@ export const FormEngine = ({
     [JSON.stringify(options), JSON.stringify(availableOptions), JSON.stringify(localValue.fields)]
   );
 
-  const getInvalidOptions = useCallback((): TQorusFormFieldSchema[] => {
-    return reduce(
+  const getValidityData = useCallback((): IFormValidityData => {
+    const fields: IFormFieldValidityData[] = reduce(
       availableOptions,
-      (invalidOptions, option, optionName) => {
-        if (
-          !isOptionValid(
-            optionName,
-            (option as IQorusFormField).type ||
-              (options?.[optionName]?.ui_type as TQorusType) ||
-              (options?.[optionName]?.type as TQorusType),
-            (option as IQorusFormField).value
-          )
-        ) {
-          invalidOptions.push(options?.[optionName] as TQorusFormFieldSchema);
+      (result, option, optionName) => {
+        const type =
+          (option as IQorusFormField).type ||
+          (options?.[optionName]?.ui_type as TQorusType) ||
+          (options?.[optionName]?.type as TQorusType);
+        const optionValue = (option as IQorusFormField).value;
+
+        const isRequired = options?.[optionName]?.required;
+        const hasRequiredGroups = !!options?.[optionName]?.required_groups;
+        const isEmpty = optionValue === undefined || optionValue === '';
+
+        let validation: IValidationResult;
+
+        if (!isRequired && !hasRequiredGroups && isEmpty) {
+          validation = { isValid: true, reasons: [] };
+        } else {
+          validation = validateFieldWithResult(getType(type), optionValue, {
+            has_to_have_value: true,
+            optionSchema: options,
+            options: availableOptions,
+            ...options?.[optionName],
+          } as any);
         }
-        return invalidOptions;
+
+        result.push({
+          fieldName: optionName,
+          type: getType(type),
+          value: optionValue,
+          validation,
+        });
+
+        return result;
       },
-      [] as TQorusFormFieldSchema[]
+      [] as IFormFieldValidityData[]
     );
+
+    const invalidFields = fields.filter((f) => !f.validation.isValid);
+
+    return {
+      isValid: invalidFields.length === 0,
+      fields,
+      invalidFields,
+    };
   }, [
     JSON.stringify(availableOptions),
     JSON.stringify(options),
     JSON.stringify(localValue.fields),
   ]);
 
-  const optionsAreValid = useMemo(() => getInvalidOptions().length === 0, [getInvalidOptions]);
+  const validityData = useMemo(() => getValidityData(), [getValidityData]);
+  const optionsAreValid = validityData.isValid;
 
   useEffect(() => {
-    onValidityChange?.(optionsAreValid);
-  }, [optionsAreValid]);
+    onValidityChange?.(optionsAreValid, validityData);
+  }, [JSON.stringify(validityData)]);
 
   const shownOptions = useMemo((): TQorusForm => {
     return reduce(
@@ -986,7 +1032,7 @@ export const FormEngine = ({
           minimal
           contentRenderer={(children) => (
             <>
-              {size(getInvalidOptions()) && !readOnly ?
+              {size(validityData.invalidFields) && !readOnly ?
                 <ReqoreMessage
                   intent={showInvalidOptionsOnly ? 'info' : 'danger'}
                   opaque={false}
@@ -996,7 +1042,7 @@ export const FormEngine = ({
                 >
                   {showInvalidOptionsOnly ?
                     'Showing invalid fields only. Click here again to show all fields.'
-                  : `${size(getInvalidOptions()) < 2 ? 'A field is not valid and requires' : `${size(getInvalidOptions())} fields are not valid and require`} attention. Click here to only show invalid fields.`
+                  : `${size(validityData.invalidFields) < 2 ? 'A field is not valid and requires' : `${size(validityData.invalidFields)} fields are not valid and require`} attention. Click here to only show invalid fields.`
                   }
                 </ReqoreMessage>
               : null}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,6 +1,16 @@
 export * from './components/form';
 export * from './components/log/Log';
 export {
+  validateField,
+  validateFieldWithResult,
+  isValueSet,
+  getTypeFromValue,
+  maybeParseYaml,
+  hasAllDependenciesFullfilled,
+  validateOptionWithRequiredGroups,
+} from './helpers/validations';
+export type { IValidationResult } from './helpers/validations';
+export {
   IReqraftMenuItem,
   IReqraftMenuProps,
   ReqraftMenu,


### PR DESCRIPTION
## Summary
- **Enhanced `onValidityChange`** — the callback now receives `(isValid: boolean, data: IFormValidityData)` where `IFormValidityData` contains per-field validation results (`fieldName`, `type`, `value`, `validation: IValidationResult` with `reason`/`reasons`), plus pre-filtered `invalidFields` for convenience.
- **Exported validation utilities** — `validateField`, `validateFieldWithResult`, `isValueSet`, `getTypeFromValue`, `maybeParseYaml`, `hasAllDependenciesFullfilled`, and `validateOptionWithRequiredGroups` are now importable from `@qoretechnologies/reqraft`.
- New `IFormValidityData` and `IFormFieldValidityData` interfaces exported for consumer type safety.

## Test plan
- [x] 15 new unit tests for `validateFieldWithResult` detailed output and export availability (142 total, all pass)
- [x] New `OnValidityChange` Storybook story that renders validity data and asserts callback args via `play` function
- [x] `yarn precheck` passes (lint + tests + tsc)

🤖 Generated with [Claude Code](https://claude.com/claude-code)