### PR TITLE
chore: bump version to 0.8.3 and update form field types

### DIFF
--- a/__tests__/arrayAutoField.test.tsx
+++ b/__tests__/arrayAutoField.test.tsx
@@ -1,0 +1,365 @@
+/**
+ * Unit tests for src/components/form/fields/array/ArrayAutoField.tsx
+ *
+ * Tests the compact tag-based UI for non-hash/non-list element types
+ * and the panel-based UI for hash/list types.
+ *
+ * ReQore components are mocked to avoid ESM import issues with nanoid.
+ */
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import React from 'react';
+
+// ── Mock @qoretechnologies/reqore ────────────────────────────────────────────
+jest.mock('@qoretechnologies/reqore', () => ({
+  ReqoreButton: ({ children, onClick, disabled, className, icon, ...rest }: any) => (
+    <button onClick={onClick} disabled={disabled} className={className} data-icon={icon} {...rest}>
+      {children}
+    </button>
+  ),
+  ReqoreControlGroup: ({ children, className, onKeyDown, ...rest }: any) => (
+    <div className={className} onKeyDown={onKeyDown} {...rest}>
+      {children}
+    </div>
+  ),
+  ReqorePanel: ({ children, className, actions, label, badge }: any) => (
+    <div className={className} data-label={label} data-badge={badge}>
+      {children}
+      {actions?.map((a: any, i: number) =>
+        a.show !== false ? (
+          <button key={i} className={a.className} onClick={a.onClick}>
+            {a.tooltip}
+          </button>
+        ) : null
+      )}
+    </div>
+  ),
+  ReqoreTag: ({ label, className, actions, intent }: any) => (
+    <span className={className} data-intent={intent}>
+      {label}
+      {actions?.map((a: any, i: number) => (
+        <span
+          key={i}
+          className={a.className}
+          onClick={a.onClick}
+          role='button'
+          data-tooltip={a.tooltip}
+        />
+      ))}
+    </span>
+  ),
+  ReqoreTagGroup: ({ children }: any) => <div className='reqore-tag-group'>{children}</div>,
+  ReqoreVerticalSpacer: () => <div />,
+  useReqoreProperty: () => jest.fn(),
+}));
+
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import {
+  ArrayAutoField,
+  IArrayAutoFieldProps,
+} from '../src/components/form/fields/array/ArrayAutoField';
+
+const stringRenderItem: IArrayAutoFieldProps['renderItem'] = ({ value, onChange }) => (
+  <input
+    data-testid='array-input'
+    value={(value as string) ?? ''}
+    onChange={(e) => onChange(e.target.value)}
+  />
+);
+
+const renderField = (props: Partial<IArrayAutoFieldProps> = {}) => {
+  const defaultProps: IArrayAutoFieldProps = {
+    name: 'test',
+    onChange: jest.fn(),
+    renderItem: stringRenderItem,
+    type: 'string',
+    value: [],
+    ...props,
+  };
+
+  return render(<ArrayAutoField {...defaultProps} />);
+};
+
+const q = (sel: string) => document.querySelector(sel);
+const qa = (sel: string) => document.querySelectorAll(sel);
+
+// ─── compact mode (non-hash, non-list) ────────────────────────────────────────
+
+describe('ArrayAutoField compact mode', () => {
+  it('renders compact UI for string type', () => {
+    renderField({ type: 'string', value: ['a', 'b'] });
+
+    expect(qa('.array-auto-compact-tag').length).toBe(2);
+    expect(qa('.array-auto-item').length).toBe(0);
+  });
+
+  it('renders compact UI for int type', () => {
+    renderField({ type: 'int', value: [1, 2, 3] });
+
+    expect(qa('.array-auto-compact-tag').length).toBe(3);
+  });
+
+  it('renders tags with correct labels', () => {
+    renderField({ type: 'string', value: ['hello', 'world'] });
+
+    expect(screen.getByText('hello')).toBeTruthy();
+    expect(screen.getByText('world')).toBeTruthy();
+  });
+
+  it('renders no tags when value is empty', () => {
+    renderField({ type: 'string', value: [] });
+
+    expect(qa('.array-auto-compact-tag').length).toBe(0);
+  });
+
+  it('renders input field for adding items', () => {
+    renderField({ type: 'string', value: [] });
+
+    expect(screen.getByTestId('array-input')).toBeTruthy();
+  });
+
+  it('renders confirm button that is disabled when input is empty', () => {
+    renderField({ type: 'string', value: [] });
+
+    const confirmBtn = q('.array-auto-compact-confirm') as HTMLButtonElement;
+    expect(confirmBtn).toBeTruthy();
+    expect(confirmBtn.disabled).toBe(true);
+  });
+
+  it('adds a new item when confirm is clicked', async () => {
+    const onChange = jest.fn();
+    renderField({ type: 'string', value: ['existing'], onChange });
+
+    const input = screen.getByTestId('array-input');
+    fireEvent.change(input, { target: { value: 'new' } });
+
+    const confirmBtn = q('.array-auto-compact-confirm') as HTMLButtonElement;
+    await waitFor(() => expect(confirmBtn.disabled).toBe(false));
+    fireEvent.click(confirmBtn);
+
+    await waitFor(() => {
+      const calls = onChange.mock.calls;
+      const lastCall = calls[calls.length - 1];
+      expect(lastCall[1]).toEqual(['existing', 'new']);
+    });
+  });
+
+  it('adds a new item on Enter key', async () => {
+    const onChange = jest.fn();
+    renderField({ type: 'string', value: [], onChange });
+
+    const input = screen.getByTestId('array-input');
+    fireEvent.change(input, { target: { value: 'enter-item' } });
+
+    const container = q('.array-auto-compact') as HTMLElement;
+    fireEvent.keyDown(container, { key: 'Enter' });
+
+    await waitFor(() => {
+      const calls = onChange.mock.calls;
+      const lastCall = calls[calls.length - 1];
+      expect(lastCall[1]).toEqual(['enter-item']);
+    });
+  });
+
+  it('populates input when edit action is clicked', async () => {
+    renderField({ type: 'string', value: ['editable'] });
+
+    const editBtn = q('.array-auto-compact-edit') as HTMLElement;
+    fireEvent.click(editBtn);
+
+    await waitFor(() => {
+      const input = screen.getByTestId('array-input') as HTMLInputElement;
+      expect(input.value).toBe('editable');
+    });
+  });
+
+  it('updates item when editing and confirm is clicked', async () => {
+    const onChange = jest.fn();
+    renderField({ type: 'string', value: ['original', 'keep'], onChange });
+
+    // Click edit on first tag
+    const editBtns = qa('.array-auto-compact-edit');
+    fireEvent.click(editBtns[0]);
+
+    await waitFor(() => {
+      const input = screen.getByTestId('array-input') as HTMLInputElement;
+      expect(input.value).toBe('original');
+    });
+
+    // Change the value
+    const input = screen.getByTestId('array-input');
+    fireEvent.change(input, { target: { value: 'modified' } });
+
+    // Confirm
+    const confirmBtn = q('.array-auto-compact-confirm') as HTMLButtonElement;
+    await waitFor(() => expect(confirmBtn.disabled).toBe(false));
+    fireEvent.click(confirmBtn);
+
+    await waitFor(() => {
+      const calls = onChange.mock.calls;
+      const lastCall = calls[calls.length - 1];
+      expect(lastCall[1]).toEqual(['modified', 'keep']);
+    });
+  });
+
+  it('removes item when remove action is clicked', async () => {
+    const onChange = jest.fn();
+    renderField({ type: 'string', value: ['a', 'b', 'c'], onChange });
+
+    // Remove second tag
+    const removeBtns = qa('.array-auto-compact-remove');
+    fireEvent.click(removeBtns[1]);
+
+    await waitFor(() => {
+      const calls = onChange.mock.calls;
+      const lastCall = calls[calls.length - 1];
+      expect(lastCall[1]).toEqual(['a', 'c']);
+    });
+  });
+
+  it('cancels editing on Escape key', async () => {
+    renderField({ type: 'string', value: ['test'] });
+
+    // Start editing
+    const editBtn = q('.array-auto-compact-edit') as HTMLElement;
+    fireEvent.click(editBtn);
+
+    await waitFor(() => {
+      expect(q('.array-auto-compact-cancel')).toBeTruthy();
+    });
+
+    // Press Escape
+    const container = q('.array-auto-compact') as HTMLElement;
+    fireEvent.keyDown(container, { key: 'Escape' });
+
+    // Cancel button should disappear
+    await waitFor(() => {
+      expect(q('.array-auto-compact-cancel')).toBeNull();
+    });
+  });
+
+  it('shows cancel button only during editing', () => {
+    renderField({ type: 'string', value: ['test'] });
+
+    // Not editing — no cancel button
+    expect(q('.array-auto-compact-cancel')).toBeNull();
+
+    // Start editing
+    const editBtn = q('.array-auto-compact-edit') as HTMLElement;
+    fireEvent.click(editBtn);
+
+    // Cancel button should appear
+    expect(q('.array-auto-compact-cancel')).toBeTruthy();
+  });
+
+  it('does not show edit/remove actions when disabled', () => {
+    renderField({ type: 'string', value: ['locked'], disabled: true });
+
+    expect(qa('.array-auto-compact-edit').length).toBe(0);
+    expect(qa('.array-auto-compact-remove').length).toBe(0);
+    expect(q('.array-auto-compact-confirm')).toBeNull();
+  });
+
+  it('does not show edit/remove actions when readOnly', () => {
+    renderField({ type: 'string', value: ['locked'], readOnly: true });
+
+    expect(qa('.array-auto-compact-edit').length).toBe(0);
+    expect(qa('.array-auto-compact-remove').length).toBe(0);
+    expect(q('.array-auto-compact-confirm')).toBeNull();
+  });
+
+  it('clears input after adding an item', async () => {
+    renderField({ type: 'string', value: [] });
+
+    const input = screen.getByTestId('array-input');
+    fireEvent.change(input, { target: { value: 'temp' } });
+
+    const confirmBtn = q('.array-auto-compact-confirm') as HTMLButtonElement;
+    await waitFor(() => expect(confirmBtn.disabled).toBe(false));
+    fireEvent.click(confirmBtn);
+
+    // Input should be cleared after confirm
+    await waitFor(() => {
+      const newInput = screen.getByTestId('array-input') as HTMLInputElement;
+      expect(newInput.value).toBe('');
+    });
+  });
+
+  it('adjusts editing index when removing item before edited item', async () => {
+    const onChange = jest.fn();
+    renderField({ type: 'string', value: ['a', 'b', 'c'], onChange });
+
+    // Start editing the third item (index 2)
+    const editBtns = qa('.array-auto-compact-edit');
+    fireEvent.click(editBtns[2]);
+
+    await waitFor(() => {
+      const input = screen.getByTestId('array-input') as HTMLInputElement;
+      expect(input.value).toBe('c');
+    });
+
+    // Remove the first item — editing index should shift from 2 to 1
+    const removeBtns = qa('.array-auto-compact-remove');
+    fireEvent.click(removeBtns[0]);
+
+    // Change the value and confirm — should update the correct item
+    const input = screen.getByTestId('array-input');
+    fireEvent.change(input, { target: { value: 'c-edited' } });
+
+    const confirmBtn = q('.array-auto-compact-confirm') as HTMLButtonElement;
+    await waitFor(() => expect(confirmBtn.disabled).toBe(false));
+    fireEvent.click(confirmBtn);
+
+    await waitFor(() => {
+      const calls = onChange.mock.calls;
+      const lastCall = calls[calls.length - 1];
+      expect(lastCall[1]).toEqual(['b', 'c-edited']);
+    });
+  });
+
+  it('cancels editing when the edited item is removed', async () => {
+    renderField({ type: 'string', value: ['only'] });
+
+    // Start editing
+    const editBtn = q('.array-auto-compact-edit') as HTMLElement;
+    fireEvent.click(editBtn);
+
+    await waitFor(() => {
+      expect(q('.array-auto-compact-cancel')).toBeTruthy();
+    });
+
+    // Remove the item being edited
+    const removeBtn = q('.array-auto-compact-remove') as HTMLElement;
+    fireEvent.click(removeBtn);
+
+    // Should exit editing mode
+    await waitFor(() => {
+      expect(q('.array-auto-compact-cancel')).toBeNull();
+    });
+  });
+});
+
+// ─── complex mode (hash/list) ─────────────────────────────────────────────────
+
+describe('ArrayAutoField complex mode', () => {
+  it('renders panel-based UI for hash type', () => {
+    renderField({ type: 'hash', value: [{}] });
+
+    expect(qa('.array-auto-item').length).toBe(1);
+    expect(qa('.array-auto-compact-tag').length).toBe(0);
+  });
+
+  it('renders panel-based UI for list type', () => {
+    renderField({ type: 'list', value: [[]] });
+
+    expect(qa('.array-auto-item').length).toBe(1);
+    expect(qa('.array-auto-compact-tag').length).toBe(0);
+  });
+
+  it('renders add button for complex mode', () => {
+    renderField({ type: 'hash', value: [] });
+
+    expect(screen.getByText(/Add new item/)).toBeTruthy();
+  });
+});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qoretechnologies/reqraft",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "description": "ReQraft is a collection of React components and hooks that are used across Qore Technologies' products made using the ReQore component library from Qore.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/components/form/fields/Field.tsx
+++ b/src/components/form/fields/Field.tsx
@@ -13,20 +13,19 @@ import { useId } from 'react';
 import { typedToYaml } from '../../../helpers/common';
 import { useArgSchema } from '../../../hooks/useArgSchema';
 import { TFormFieldType, TFormFieldValueType } from '../../../types/Form';
-import BooleanFormField, { IBooleanFormFieldProps } from './boolean/Boolean';
+import BooleanFormField from './boolean/Boolean';
 import ColorFormField, { IColorFormFieldProps } from './color/Color';
-import CronFormField, { ICronFormFieldProps } from './cron/Cron';
-import { DateFormField, IDateFormFieldProps } from './date/Date';
-import { IFileFormFieldValue, IReqraftFileFormFieldProps, ReqraftFileFormField } from './file/File';
-import LongStringFormField, { ILongStringFormFieldProps } from './long-string/LongString';
-import MarkdownFormField, { IMarkdownFormFieldProps } from './markdown/Markdown';
+import CronFormField from './cron/Cron';
+import { DateFormField } from './date/Date';
+import { IFileFormFieldValue, ReqraftFileFormField } from './file/File';
+import LongStringFormField from './long-string/LongString';
+import MarkdownFormField from './markdown/Markdown';
 import { MultiSelectFormField } from './multi-select/MultiSelectFormField';
 import NumberFormField from './number/Number';
 import { ReqraftObjectFormField } from './object/Object';
-import RadioGroupFormField, { IRadioGroupFormFieldProps } from './radio-group/RadioGroup';
-import { IRichTextFormFieldProps, RichTextFormField } from './rich-text/RichText';
-import { ISelectFormFieldProps, SelectFormField } from './select/Select';
-import { IStringFormFieldProps, StringFormField } from './string/String';
+import { RichTextFormField } from './rich-text/RichText';
+import { SelectFormField } from './select/Select';
+import { StringFormField } from './string/String';
 import { ArrayAutoField } from './array/ArrayAutoField';
 // Direct import — circular dep (FormEngine → TemplateField → FormField → FormEngine) is safe
 // because modules are all loaded before any component renders
@@ -35,11 +34,11 @@ import { FormEngine } from '../engine/FormEngine';
 const mapQorusTypeToFormFieldType = (type: string): TFormFieldType => {
   switch (type) {
     case 'richtext': return 'richtext';
-    case 'bool': case 'boolean': return 'boolean';
-    case 'int': case 'integer': case 'float': case 'number': return 'number';
+    case 'bool': case 'boolean': return 'bool';
+    case 'int': case 'integer': case 'float': case 'number': return 'int';
     case 'date': return 'date';
     case 'file': return 'file';
-    case 'rgbcolor': return 'color';
+    case 'rgbcolor': return 'rgbcolor';
     case 'hash': case 'free-hash': return 'hash';
     case 'list': case 'free-list': return 'list';
     default: return 'long-string';
@@ -72,21 +71,7 @@ export interface IFormFieldProps<T extends TFormFieldType = TFormFieldType> exte
   element_allowed_values?: IQorusAllowedValue[];
   element_allowed_values_creatable?: boolean;
 
-  fieldProps?: Omit<
-    T extends 'string' ? IStringFormFieldProps
-    : T extends 'boolean' ? IBooleanFormFieldProps
-    : T extends 'radio' ? IRadioGroupFormFieldProps
-    : T extends 'color' ? IColorFormFieldProps
-    : T extends 'long-string' ? ILongStringFormFieldProps
-    : T extends 'markdown' ? IMarkdownFormFieldProps
-    : T extends 'cron' ? ICronFormFieldProps
-    : T extends 'richtext' ? IRichTextFormFieldProps
-    : T extends 'date' ? IDateFormFieldProps
-    : T extends 'file' ? IReqraftFileFormFieldProps
-    : T extends 'select' ? ISelectFormFieldProps
-    : never,
-    'value' | 'onChange'
-  >;
+  fieldProps?: Record<string, any>;
 
   label?: IReqoreLabelProps['label'];
   labelPosition?: 'top' | 'left' | 'right' | 'bottom';
@@ -130,7 +115,7 @@ export const FormField = <T extends TFormFieldType>({
       return null;
     }
 
-    switch (type) {
+    switch (type as string) {
       case 'string':
         return (
           <StringFormField
@@ -142,11 +127,12 @@ export const FormField = <T extends TFormFieldType>({
           />
         );
 
+      case 'bool':
       case 'boolean':
         return (
           <BooleanFormField
             {...rest}
-            {...(fieldProps as IFormFieldProps<'boolean'>['fieldProps'])}
+            {...(fieldProps as IFormFieldProps<'bool'>['fieldProps'])}
             checked={value as boolean}
             onChange={(checked) => {
               handleChange(checked as TFormFieldValueType<T>);
@@ -155,11 +141,14 @@ export const FormField = <T extends TFormFieldType>({
           />
         );
 
+      case 'int':
+      case 'integer':
+      case 'float':
       case 'number':
         return (
           <NumberFormField
             {...rest}
-            {...(fieldProps as IFormFieldProps<'number'>['fieldProps'])}
+            {...(fieldProps as IFormFieldProps<'int'>['fieldProps'])}
             value={value as number}
             onChange={(value) => {
               handleChange(value as TFormFieldValueType<T>);
@@ -168,28 +157,15 @@ export const FormField = <T extends TFormFieldType>({
           />
         );
 
-      case 'color':
+      case 'rgbcolor':
         return (
           <ColorFormField
             {...rest}
-            {...(fieldProps as IFormFieldProps<'color'>['fieldProps'])}
+            {...(fieldProps as IFormFieldProps<'rgbcolor'>['fieldProps'])}
             value={value as IColorFormFieldProps['value']}
             onChange={(color) => {
               handleChange(color as TFormFieldValueType<T>);
             }}
-          />
-        );
-
-      case 'radio':
-        return (
-          <RadioGroupFormField
-            {...rest}
-            {...(fieldProps as IFormFieldProps<'radio'>['fieldProps'])}
-            value={value as TFormFieldValueType<T>}
-            onChange={(selected) => {
-              handleChange(selected as TFormFieldValueType<T>);
-            }}
-            id={id}
           />
         );
 
@@ -210,7 +186,7 @@ export const FormField = <T extends TFormFieldType>({
         return (
           <MarkdownFormField
             {...rest}
-            {...(fieldProps as IFormFieldProps<'markdown'>['fieldProps'])}
+            {...(fieldProps as any)}
             value={value as TFormFieldValueType<T>}
             onChange={(selected) => {
               handleChange(selected as TFormFieldValueType<T>);
@@ -223,7 +199,7 @@ export const FormField = <T extends TFormFieldType>({
         return (
           <CronFormField
             {...rest}
-            {...(fieldProps as IFormFieldProps<'cron'>['fieldProps'])}
+            {...(fieldProps as any)}
             value={value as TFormFieldValueType<T>}
             onChange={(selected) => {
               handleChange(selected as TFormFieldValueType<T>);
@@ -272,10 +248,12 @@ export const FormField = <T extends TFormFieldType>({
         );
 
       case 'select':
+      case 'select-string':
+      case 'enum':
         return (
           <SelectFormField
             {...rest}
-            {...(fieldProps as IFormFieldProps<'select'>['fieldProps'])}
+            {...(fieldProps as any)}
             value={value}
             onChange={(val) => {
               handleChange(val as TFormFieldValueType<T>);

--- a/src/components/form/fields/array/ArrayAutoField.stories.tsx
+++ b/src/components/form/fields/array/ArrayAutoField.stories.tsx
@@ -1,0 +1,277 @@
+import { ReqoreControlGroup } from '@qoretechnologies/reqore';
+import { StoryObj } from '@storybook/react';
+import { expect, fireEvent, fn, waitFor, within } from '@storybook/test';
+import { useState } from 'react';
+import { StoryMeta } from '../../../../types';
+import { NumberFormField } from '../number/Number';
+import { StringFormField } from '../string/String';
+import { ArrayAutoField, IArrayAutoFieldProps } from './ArrayAutoField';
+
+const stringRenderItem: IArrayAutoFieldProps['renderItem'] = ({
+  value,
+  onChange,
+  disabled,
+  readOnly,
+  size,
+  ...rest
+}) => (
+  <StringFormField
+    value={(value as string) ?? ''}
+    onChange={(v) => onChange(v)}
+    disabled={disabled}
+    readOnly={readOnly}
+    size={size as any}
+    aria-label='Array item input'
+    {...(rest as any)}
+  />
+);
+
+const numberRenderItem: IArrayAutoFieldProps['renderItem'] = ({
+  value,
+  onChange,
+  disabled,
+  readOnly,
+  size,
+  ...rest
+}) => (
+  <NumberFormField
+    value={value as number}
+    onChange={(v) => onChange(v)}
+    disabled={disabled}
+    readOnly={readOnly}
+    size={size as any}
+    aria-label='Array item input'
+    type='int'
+    {...(rest as any)}
+  />
+);
+
+const meta = {
+  component: ArrayAutoField,
+  title: 'Components/Form/Auto Array',
+  args: {
+    name: 'testArray',
+    onChange: fn(),
+    renderItem: stringRenderItem,
+    type: 'string',
+  },
+  render(args) {
+    const [value, setValue] = useState(args.value);
+
+    return (
+      <ReqoreControlGroup vertical>
+        <ArrayAutoField
+          {...args}
+          value={value}
+          onChange={(_name, val) => {
+            args.onChange?.(_name, val);
+            setValue(val);
+          }}
+        />
+      </ReqoreControlGroup>
+    );
+  },
+} as StoryMeta<typeof ArrayAutoField>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+// ─── Compact mode stories (non-hash, non-list) ──────────────────────────────
+
+export const CompactEmpty: Story = {
+  args: {
+    type: 'string',
+    value: [],
+  },
+  async play({ canvasElement }) {
+    const canvas = within(canvasElement);
+
+    // Should show the input field but no tags
+    await expect(canvas.queryByRole('button', { name: /add item/i })).not.toBeInTheDocument();
+    await expect(document.querySelectorAll('.array-auto-compact-tag').length).toBe(0);
+
+    // Confirm button should be disabled when input is empty
+    const confirmBtn = document.querySelector('.array-auto-compact-confirm') as HTMLButtonElement;
+    await expect(confirmBtn).toBeInTheDocument();
+    await expect(confirmBtn).toBeDisabled();
+  },
+};
+
+export const CompactWithValues: Story = {
+  args: {
+    type: 'string',
+    value: ['hello', 'world'],
+  },
+  async play({ canvasElement }) {
+    const canvas = within(canvasElement);
+
+    // Should show 2 tags
+    await waitFor(
+      () => expect(document.querySelectorAll('.array-auto-compact-tag').length).toBe(2),
+      { timeout: 5000 }
+    );
+
+    // Tags should display the values
+    await expect(canvas.getByText('hello')).toBeInTheDocument();
+    await expect(canvas.getByText('world')).toBeInTheDocument();
+  },
+};
+
+export const CompactAddItem: Story = {
+  args: {
+    type: 'string',
+    value: ['existing'],
+  },
+  async play({ args }) {
+    await waitFor(
+      () => expect(document.querySelectorAll('.array-auto-compact-tag').length).toBe(1),
+      { timeout: 5000 }
+    );
+
+    // Type a value into the input
+    const input = document.querySelector('.array-auto-compact .reqore-input') as HTMLInputElement;
+    await fireEvent.change(input, { target: { value: 'new item' } });
+
+    // Click confirm
+    const confirmBtn = document.querySelector('.array-auto-compact-confirm') as HTMLButtonElement;
+    await waitFor(() => expect(confirmBtn).not.toBeDisabled());
+    await fireEvent.click(confirmBtn);
+
+    // Should now have 2 tags
+    await waitFor(
+      () => expect(document.querySelectorAll('.array-auto-compact-tag').length).toBe(2),
+      { timeout: 5000 }
+    );
+
+    // onChange should have been called with both values
+    await waitFor(() => {
+      const calls = (args.onChange as ReturnType<typeof fn>).mock.calls;
+      const lastCall = calls[calls.length - 1];
+      expect(lastCall[1]).toEqual(['existing', 'new item']);
+    });
+  },
+};
+
+export const CompactEditItem: Story = {
+  args: {
+    type: 'string',
+    value: ['alpha', 'beta'],
+  },
+  async play({ args }) {
+    await waitFor(
+      () => expect(document.querySelectorAll('.array-auto-compact-tag').length).toBe(2),
+      { timeout: 5000 }
+    );
+
+    // Click edit on the first tag
+    const editBtns = document.querySelectorAll('.array-auto-compact-edit');
+    await fireEvent.click(editBtns[0]);
+
+    // The input should be populated with the tag's value
+    const input = document.querySelector('.array-auto-compact .reqore-input') as HTMLInputElement;
+    await waitFor(() => expect(input.value).toBe('alpha'));
+
+    // Change the value
+    await fireEvent.change(input, { target: { value: 'alpha-edited' } });
+
+    // Click confirm (should show check icon in edit mode)
+    const confirmBtn = document.querySelector('.array-auto-compact-confirm') as HTMLButtonElement;
+    await waitFor(() => expect(confirmBtn).not.toBeDisabled());
+    await fireEvent.click(confirmBtn);
+
+    // Should still have 2 tags, first one updated
+    await waitFor(
+      () => expect(document.querySelectorAll('.array-auto-compact-tag').length).toBe(2),
+      { timeout: 5000 }
+    );
+
+    // onChange should have been called with updated values
+    await waitFor(() => {
+      const calls = (args.onChange as ReturnType<typeof fn>).mock.calls;
+      const lastCall = calls[calls.length - 1];
+      expect(lastCall[1]).toEqual(['alpha-edited', 'beta']);
+    });
+  },
+};
+
+export const CompactRemoveItem: Story = {
+  args: {
+    type: 'string',
+    value: ['one', 'two', 'three'],
+  },
+  async play({ args }) {
+    await waitFor(
+      () => expect(document.querySelectorAll('.array-auto-compact-tag').length).toBe(3),
+      { timeout: 5000 }
+    );
+
+    // Click remove on the second tag ("two")
+    const removeBtns = document.querySelectorAll('.array-auto-compact-remove');
+    await fireEvent.click(removeBtns[1]);
+
+    // Should now have 2 tags
+    await waitFor(
+      () => expect(document.querySelectorAll('.array-auto-compact-tag').length).toBe(2),
+      { timeout: 5000 }
+    );
+
+    // onChange should have been called without "two"
+    await waitFor(() => {
+      const calls = (args.onChange as ReturnType<typeof fn>).mock.calls;
+      const lastCall = calls[calls.length - 1];
+      expect(lastCall[1]).toEqual(['one', 'three']);
+    });
+  },
+};
+
+export const CompactWithNumbers: Story = {
+  args: {
+    type: 'int',
+    value: [10, 20, 30],
+    renderItem: numberRenderItem,
+  },
+  async play() {
+    await waitFor(
+      () => expect(document.querySelectorAll('.array-auto-compact-tag').length).toBe(3),
+      { timeout: 5000 }
+    );
+  },
+};
+
+export const CompactDisabled: Story = {
+  args: {
+    type: 'string',
+    value: ['locked'],
+    disabled: true,
+  },
+  async play() {
+    await waitFor(
+      () => expect(document.querySelectorAll('.array-auto-compact-tag').length).toBe(1),
+      { timeout: 5000 }
+    );
+
+    // Should not have edit/remove actions
+    await expect(document.querySelectorAll('.array-auto-compact-edit').length).toBe(0);
+    await expect(document.querySelectorAll('.array-auto-compact-remove').length).toBe(0);
+
+    // Should not have confirm button
+    await expect(document.querySelector('.array-auto-compact-confirm')).not.toBeInTheDocument();
+  },
+};
+
+// ─── Complex mode stories (hash/list) ────────────────────────────────────────
+
+export const ComplexHashItems: Story = {
+  args: {
+    type: 'hash',
+    value: [{ key: 'value' }],
+    display_name: 'Hash Items',
+  },
+  async play() {
+    // Should render panel-based UI, not compact tags
+    await waitFor(() => expect(document.querySelectorAll('.array-auto-item').length).toBe(1), {
+      timeout: 5000,
+    });
+    await expect(document.querySelectorAll('.array-auto-compact-tag').length).toBe(0);
+  },
+};

--- a/src/components/form/fields/array/ArrayAutoField.tsx
+++ b/src/components/form/fields/array/ArrayAutoField.tsx
@@ -3,12 +3,13 @@ import {
   ReqoreControlGroup,
   ReqorePanel,
   ReqoreTag,
+  ReqoreTagGroup,
   ReqoreVerticalSpacer,
   useReqoreProperty,
 } from '@qoretechnologies/reqore';
 import { IQorusFormSchema } from '@qoretechnologies/ts-toolkit';
 import { map, size } from 'lodash';
-import { memo, useCallback, useEffect, useState } from 'react';
+import React, { memo, useCallback, useEffect, useRef, useState } from 'react';
 import { useDebounce } from 'react-use';
 import { validateFieldWithResult } from '../../../../helpers/validations';
 
@@ -48,6 +49,11 @@ const defaultValueByType: Record<string, unknown> = {
   list: [],
 };
 
+const formatTagLabel = (val: unknown): string => {
+  if (val === undefined || val === null) return '';
+  return String(val);
+};
+
 export const ArrayAutoField = memo(
   ({
     name,
@@ -65,6 +71,10 @@ export const ArrayAutoField = memo(
   }: IArrayAutoFieldProps) => {
     const confirmAction = useReqoreProperty('confirmAction');
     const [localValue, setLocalValue] = useState(value);
+    // Compact mode state: staging value for the input field and optional editing index
+    const [inputValue, setInputValue] = useState<unknown>(undefined);
+    const [editingIndex, setEditingIndex] = useState<number | null>(null);
+    const inputKeyRef = useRef(0);
 
     useEffect(() => {
       setLocalValue(value);
@@ -82,12 +92,9 @@ export const ArrayAutoField = memo(
       setLocalValue((prev) => [...(prev || []), defaultValueByType[type] ?? undefined]);
     }, [type]);
 
-    const removeItem = useCallback(
-      (idx: number) => {
-        setLocalValue((prev) => (prev || []).filter((_, i) => i !== idx));
-      },
-      []
-    );
+    const removeItem = useCallback((idx: number) => {
+      setLocalValue((prev) => (prev || []).filter((_, i) => i !== idx));
+    }, []);
 
     const handleItemChange = useCallback((idx: number, itemValue: unknown) => {
       setLocalValue((prev) => {
@@ -116,6 +123,159 @@ export const ArrayAutoField = memo(
       }
       return null;
     };
+
+    // ── Compact mode handlers ──────────────────────────────────────────────
+
+    const resetInput = useCallback(() => {
+      setInputValue(undefined);
+      setEditingIndex(null);
+      inputKeyRef.current += 1;
+    }, []);
+
+    const confirmInput = useCallback(() => {
+      if (inputValue === undefined || inputValue === '') return;
+
+      if (editingIndex !== null) {
+        // Update existing item
+        setLocalValue((prev) => {
+          const next = [...(prev || [])];
+          next[editingIndex] = inputValue;
+          return next;
+        });
+      } else {
+        // Add new item
+        setLocalValue((prev) => [...(prev || []), inputValue]);
+      }
+
+      resetInput();
+    }, [inputValue, editingIndex, resetInput]);
+
+    const handleEditTag = useCallback(
+      (idx: number) => {
+        setInputValue(localValue[idx]);
+        setEditingIndex(idx);
+        inputKeyRef.current += 1;
+      },
+      [localValue]
+    );
+
+    const handleRemoveTag = useCallback(
+      (idx: number) => {
+        // If we're editing this item, cancel the edit
+        if (editingIndex === idx) {
+          resetInput();
+        } else if (editingIndex !== null && idx < editingIndex) {
+          // Adjust editing index if removing an item before it
+          setEditingIndex((prev) => (prev !== null ? prev - 1 : null));
+        }
+        removeItem(idx);
+      },
+      [editingIndex, removeItem, resetInput]
+    );
+
+    const handleInputKeyDown = useCallback(
+      (e: React.KeyboardEvent) => {
+        if (e.key === 'Enter') {
+          e.preventDefault();
+          confirmInput();
+        } else if (e.key === 'Escape' && editingIndex !== null) {
+          e.preventDefault();
+          resetInput();
+        }
+      },
+      [confirmInput, editingIndex, resetInput]
+    );
+
+    // ── Compact mode: non-hash, non-list element types ─────────────────────
+
+    if (type !== 'hash' && type !== 'list' && type !== 'rgbcolor') {
+      const isEditing = editingIndex !== null;
+      const hasInput = inputValue !== undefined && inputValue !== '';
+
+      return (
+        <ReqoreControlGroup
+          vertical
+          fluid
+          className='array-auto-compact'
+          onKeyDown={handleInputKeyDown as any}
+        >
+          {size(localValue) > 0 && (
+            <ReqoreTagGroup>
+              {map(localValue, (val, idx) => (
+                <ReqoreTag
+                  key={`${idx}-${formatTagLabel(val)}`}
+                  label={formatTagLabel(val)}
+                  className='array-auto-compact-tag'
+                  size={fieldSize as any}
+                  intent={editingIndex === idx ? 'info' : undefined}
+                  actions={
+                    disabled || readOnly ? undefined : (
+                      [
+                        {
+                          icon: 'EditLine',
+                          tooltip: 'Edit',
+                          className: 'array-auto-compact-edit',
+                          onClick: () => handleEditTag(idx),
+                        },
+                        {
+                          icon: 'DeleteBinLine',
+                          intent: 'danger',
+                          tooltip: 'Remove',
+                          className: 'array-auto-compact-remove',
+                          onClick: () => handleRemoveTag(idx),
+                        },
+                      ]
+                    )
+                  }
+                />
+              ))}
+            </ReqoreTagGroup>
+          )}
+
+          <ReqoreControlGroup fluid>
+            <div style={{ flex: 1 }}>
+              {renderItem({
+                value: inputValue,
+                onChange: (v) => setInputValue(v),
+                index: -1,
+                type,
+                arg_schema,
+                allowed_values,
+                allowed_values_creatable,
+                disabled,
+                readOnly,
+                size: fieldSize,
+                key: inputKeyRef.current,
+              } as any)}
+            </div>
+            {!disabled && !readOnly && (
+              <>
+                <ReqoreButton
+                  icon={isEditing ? 'CheckLine' : 'AddLine'}
+                  intent={isEditing ? 'info' : undefined}
+                  className='array-auto-compact-confirm'
+                  tooltip={isEditing ? 'Save changes' : 'Add item'}
+                  disabled={!hasInput}
+                  onClick={confirmInput}
+                  fixed
+                />
+                {isEditing && (
+                  <ReqoreButton
+                    icon='CloseLine'
+                    className='array-auto-compact-cancel'
+                    tooltip='Cancel editing'
+                    onClick={resetInput}
+                    fixed
+                  />
+                )}
+              </>
+            )}
+          </ReqoreControlGroup>
+        </ReqoreControlGroup>
+      );
+    }
+
+    // ── Complex mode: hash/list element types ──────────────────────────────
 
     return (
       <ReqoreControlGroup vertical fluid>

--- a/src/components/form/fields/multi-select/MultiSelectFormField.tsx
+++ b/src/components/form/fields/multi-select/MultiSelectFormField.tsx
@@ -8,6 +8,7 @@ export interface IMultiSelectFormFieldProps {
   value?: unknown[];
   /** The fixed list of allowed items */
   items: IQorusAllowedValue[];
+  canCreateItems?: boolean;
   onChange: (value: unknown[]) => void;
   disabled?: boolean;
   size?: string;
@@ -18,7 +19,7 @@ export interface IMultiSelectFormFieldProps {
  * Used by FormField for `list` fields that have `element_allowed_values`.
  */
 export const MultiSelectFormField = memo(
-  ({ value = [], items, onChange, disabled, size }: IMultiSelectFormFieldProps) => {
+  ({ value = [], items, onChange, disabled, size, canCreateItems }: IMultiSelectFormFieldProps) => {
     const reqoreItems = useMemo<TReqoreMultiSelectItem[]>(
       () =>
         items.map((item) => ({
@@ -39,9 +40,12 @@ export const MultiSelectFormField = memo(
       <ReqoreMultiSelect
         items={reqoreItems}
         value={selectedValues}
-        onValueChange={(selected) => onChange(selected as unknown[])}
+        onValueChange={(selected) => onChange?.(selected as unknown[])}
         disabled={disabled}
         size={size as any}
+        canCreateItems={canCreateItems}
+        enterKeySelects
+        canRemoveItems
       />
     );
   }

--- a/src/components/form/fields/select/Select.tsx
+++ b/src/components/form/fields/select/Select.tsx
@@ -1,6 +1,5 @@
 import {
   ReqoreButton,
-  ReqoreControlGroup,
   ReqoreDropdown,
   ReqoreMenu,
   ReqoreMenuItem,
@@ -12,10 +11,7 @@ import { TReqoreIntent } from '@qoretechnologies/reqore/dist/constants/theme';
 import { IReqoreIconName } from '@qoretechnologies/reqore/dist/types/icons';
 import { isEqual, size } from 'lodash';
 import { memo, useCallback, useEffect, useMemo, useState } from 'react';
-import {
-  ISelectFieldCollectionItem,
-  SelectFieldCollection,
-} from './SelectCollection';
+import { ISelectFieldCollectionItem, SelectFieldCollection } from './SelectCollection';
 
 export type ISelectFormFieldItem = ISelectFieldCollectionItem;
 
@@ -215,14 +211,17 @@ export const SelectFormField = memo(
 
     const itemCount: TReqoreBadge = useMemo(
       () =>
-        hideItemCount
-          ? undefined
-          : {
-              label: size(items),
-              align: 'right' as const,
-              flat: false,
-              intent: hasError(items) ? 'danger' : hasWarning(items) ? 'warning' : undefined,
-            },
+        hideItemCount ? undefined : (
+          {
+            label: size(items),
+            align: 'right' as const,
+            flat: false,
+            intent:
+              hasError(items) ? 'danger'
+              : hasWarning(items) ? 'warning'
+              : undefined,
+          }
+        ),
       [size(items), hideItemCount]
     );
 
@@ -244,16 +243,19 @@ export const SelectFormField = memo(
           fixed
           minimal
           {...getIcon(filteredItems, filteredItems[0].value)}
-          intent={itemHasError ? 'danger' : itemHasWarning ? 'warning' : 'info'}
+          intent={
+            itemHasError ? 'danger'
+            : itemHasWarning ?
+              'warning'
+            : 'info'
+          }
           disabled={false}
         />
       );
     }
 
     if (!filteredItems || filteredItems.length === 0) {
-      return (
-        <ReqoreTag intent='muted' label='No data available' icon='ForbidLine' fixed />
-      );
+      return <ReqoreTag intent='muted' label='No data available' icon='ForbidLine' fixed />;
     }
 
     return (
@@ -268,7 +270,7 @@ export const SelectFormField = memo(
             onClose={() => setCollectionOpen(false)}
           />
         )}
-        {asMenu ? (
+        {asMenu ?
           <ReqoreMenu>
             {filteredItems.map((item) => (
               <ReqoreMenuItem
@@ -280,43 +282,39 @@ export const SelectFormField = memo(
               />
             ))}
           </ReqoreMenu>
-        ) : hasItemsWithDesc(items) && !forceDropdown ? (
-          <ReqoreControlGroup stack fluid={fluid}>
-            <ReqoreButton
-              transparent={!value}
-              minimal
-              intent={
-                hasError(items, value)
-                  ? 'danger'
-                  : hasWarning(items, value)
-                    ? 'warning'
-                    : value
-                      ? 'info'
-                      : rest.intent as TReqoreIntent
-              }
-              fluid={fluid}
-              compact
-              key={valueToShow(value) as string}
-              badge={itemCount}
-              {...getIcon(items, value)}
-              rightIcon={showRightIcon ? 'ExpandUpDownLine' : undefined}
-              onClick={(e) => {
-                e.stopPropagation();
-                setCollectionOpen(true);
-              }}
-              description={getItemShortDescription(value as string) as string}
-              tooltip={rest.tooltip as IReqoreButtonProps['tooltip']}
-              disabled={disabled}
-            >
-              {value
-                ? getLabel(items, value as string)
-                : showPlaceholder
-                  ? placeholder || 'Please select'
-                  : undefined}
-            </ReqoreButton>
-          </ReqoreControlGroup>
-        ) : (
-          <ReqoreDropdown
+        : hasItemsWithDesc(items) && !forceDropdown ?
+          <ReqoreButton
+            transparent={!value}
+            minimal
+            intent={
+              hasError(items, value) ? 'danger'
+              : hasWarning(items, value) ?
+                'warning'
+              : value ?
+                'info'
+              : (rest.intent as TReqoreIntent)
+            }
+            fluid={fluid}
+            compact
+            key={valueToShow(value) as string}
+            badge={itemCount}
+            {...getIcon(items, value)}
+            rightIcon={showRightIcon ? 'ExpandUpDownLine' : undefined}
+            onClick={(e) => {
+              e.stopPropagation();
+              setCollectionOpen(true);
+            }}
+            description={getItemShortDescription(value as string) as string}
+            tooltip={rest.tooltip as IReqoreButtonProps['tooltip']}
+            disabled={disabled}
+          >
+            {value ?
+              getLabel(items, value as string)
+            : showPlaceholder ?
+              placeholder || 'Please select'
+            : undefined}
+          </ReqoreButton>
+        : <ReqoreDropdown
             items={reqoreItems}
             listCustomTheme={{
               main: '#010811',
@@ -336,15 +334,20 @@ export const SelectFormField = memo(
             }}
             description={getItemShortDescription(value as string) as string}
             minimal
-            intent={hasError(items, value) ? 'danger' : value ? 'info' : rest.intent as TReqoreIntent}
+            intent={
+              hasError(items, value) ? 'danger'
+              : value ?
+                'info'
+              : (rest.intent as TReqoreIntent)
+            }
           >
-            {value
-              ? getLabel(items, value as string)
-              : showPlaceholder
-                ? placeholder || 'Please select'
-                : undefined}
+            {value ?
+              getLabel(items, value as string)
+            : showPlaceholder ?
+              placeholder || 'Please select'
+            : undefined}
           </ReqoreDropdown>
-        )}
+        }
       </>
     );
   }

--- a/src/components/form/fields/template/TemplateField.tsx
+++ b/src/components/form/fields/template/TemplateField.tsx
@@ -52,18 +52,18 @@ export const mapQorusTypeToFormFieldType = (type: string): TFormFieldType => {
       return 'richtext';
     case 'bool':
     case 'boolean':
-      return 'boolean';
+      return 'bool';
     case 'int':
     case 'integer':
     case 'float':
     case 'number':
-      return 'number';
+      return 'int';
     case 'date':
       return 'date';
     case 'file':
       return 'file';
     case 'rgbcolor':
-      return 'color';
+      return 'rgbcolor';
     case 'hash':
     case 'free-hash':
       return 'hash';

--- a/src/types/Form.ts
+++ b/src/types/Form.ts
@@ -1,50 +1,18 @@
+import { TQorusType } from '@qoretechnologies/ts-toolkit';
 import { IColorFormFieldProps } from '../components/form/fields/color/Color';
 
-export type TFormFieldType =
-  | 'string'
-  | 'number'
-  | 'boolean'
-  | 'date'
-  | 'time'
-  | 'datetime'
-  | 'select'
-  | 'multiSelect'
-  | 'radio'
-  | 'checkbox'
-  | 'file'
-  | 'image'
-  | 'color'
-  | 'password'
-  | 'email'
-  | 'phone'
-  | 'url'
-  | 'markdown'
-  | 'long-string'
-  | 'cron'
-  | 'richtext'
-  | 'hash'
-  | 'list';
+export type TFormFieldType = TQorusType;
 
 export type TFormFieldValueType<T> =
-  T extends 'string' ? string
-  : T extends 'number' ? number
-  : T extends 'boolean' ? boolean
+  T extends 'string' | 'long-string' | 'binary' | 'email' | 'url' | 'enum' | 'select-string' | 'file-as-string' ? string
+  : T extends 'int' | 'integer' | 'float' | 'number' ? number
+  : T extends 'bool' | 'boolean' ? boolean
   : T extends 'date' ? Date | string
-  : T extends 'time' ? Date | string
-  : T extends 'datetime' ? Date | string
-  : T extends 'select' ? string
-  : T extends 'multiSelect' ? string[]
-  : T extends 'radio' ? string
-  : T extends 'checkbox' ? boolean
+  : T extends 'hash' | 'free-hash' | 'data' ? Record<string, any>
+  : T extends 'list' | 'free-list' | 'range' ? unknown[]
+  : T extends 'rgbcolor' ? IColorFormFieldProps['value']
   : T extends 'file' ? File
-  : T extends 'image' ? string
-  : T extends 'color' ? IColorFormFieldProps['value']
-  : T extends 'password' ? string
-  : T extends 'email' ? string
-  : T extends 'phone' ? string
-  : T extends 'url' ? string
-  : T extends 'markdown' ? string
-  : T extends 'long-string' ? string
-  : T extends 'cron' ? string
   : T extends 'richtext' ? string
+  : T extends 'auto' | 'any' ? any
+  : T extends 'null' | 'nothing' ? null
   : any;


### PR DESCRIPTION
- Updated package version in package.json to 0.8.3.
- Refactored Field component imports for better clarity and consistency.
- Changed boolean and number field types to 'bool' and 'int' respectively in mapQorusTypeToFormFieldType function.
- Introduced new ArrayAutoField component with compact mode for managing array inputs.
- Enhanced MultiSelectFormField to support item creation.
- Updated SelectFormField to streamline rendering logic and improve readability.
- Simplified Form.ts type definitions by leveraging TQorusType for form field types.