### PR TITLE
fix(form): thread componentOverrides into ArrayAuto

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qoretechnologies/reqraft",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "ReQraft is a collection of React components and hooks that are used across Qore Technologies' products made using the ReQore component library from Qore.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/components/form/fields/auto/AutoFormField.tsx
+++ b/src/components/form/fields/auto/AutoFormField.tsx
@@ -649,6 +649,7 @@ function AutoField<T = any>({
                 allowed_values={rest.element_allowed_values}
                 allowed_values_creatable={rest.element_allowed_values_creatable}
                 type={effectiveElementType}
+                componentOverrides={componentOverrides}
                 onChange={(name, value) => {
                   if (!size(value)) {
                     return handleChange(name, undefined);


### PR DESCRIPTION
The componentOverrides seam resolved consumer-injected editors for scalar fields but stopped at list boundaries: a `list` field renders its elements through ArrayAuto, which never received the override map, so element editors fell back to the generic dispatch and any injected editor was silently dropped.

Forward the map into ArrayAuto; it already rest-spreads props onto each element's AutoFormField, so the per-element override lookup (by element type / ui_type) now resolves the same way scalar fields do.