### PR TITLE
feat(form-engine): forward sibling values as render-time props via inherit_props

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "react-dom": "^18.3.1"
   },
   "dependencies": {
-    "@qoretechnologies/ts-toolkit": "^0.5.78",
+    "@qoretechnologies/ts-toolkit": "^0.5.80",
     "@tanstack/react-query": "4",
     "classnames": "^2.2.6",
     "cron-validator": "^1.4.0",

--- a/src/components/form/engine/FormEngine.stories.tsx
+++ b/src/components/form/engine/FormEngine.stories.tsx
@@ -565,6 +565,108 @@ export const OptionsWithOnChangeTriggerEvents: Story = {
   },
 };
 
+// A stand-in for a host-injected `code-editor` renderer. Reqraft does not
+// ship a CodeEditor (Monaco is a heavy dep the toolkit shouldn't pull in);
+// the IDE / consumers inject one via `componentOverrides`. This stand-in
+// renders a textarea AND a visible "syntax: <language>" tag so the
+// `inherit_props` story (below) can prove the inherited `language` prop
+// flows through to the renderer at render time.
+const CodeEditorStandin = ({
+  value,
+  onChange,
+  language,
+  size,
+}: {
+  value?: unknown;
+  onChange?: (value: string) => void;
+  language?: unknown;
+  size?: TSizes;
+}) => (
+  <div data-testid='code-editor-mock'>
+    <div data-testid='code-editor-language' style={{ fontFamily: 'monospace', marginBottom: 4 }}>
+      syntax: {String(language ?? 'plain')}
+    </div>
+    <ReqoreInput
+      fluid
+      size={size}
+      icon='CodeLine'
+      placeholder='Source code (stand-in code-editor)'
+      value={typeof value === 'string' ? value : ''}
+      onChange={(event: ChangeEvent<HTMLInputElement>) => onChange?.(event.target.value)}
+    />
+  </div>
+);
+
+// qorus#347-followup: an option can declare `inherit_props` — a JSON map of
+// `<prop-name-on-renderer>` → `<sibling-field-name>` — and FormEngine
+// resolves each entry at render time, forwarding the sibling's current
+// value as a runtime prop on this field's renderer. Unlike `on_change:
+// ['refetch']` (which requires a server round-trip to reshape the
+// schema), `inherit_props` is purely a render-time prop forwarding —
+// fast, JSON-safe, and the receiving renderer decides how to use the
+// value (e.g. CodeEditor maps `language: "qore"` to its highlighter
+// mode). This story demonstrates the canonical case: a `source` field
+// (rendered by a host-injected code-editor) inherits `language` from
+// a sibling `lang` picker, so flipping the picker live-changes the
+// editor's syntax highlighting with no refetch.
+export const OptionInheritsRenderPropFromSibling: Story = {
+  args: {
+    componentOverrides: { 'code-editor': CodeEditorStandin },
+    value: {
+      lang: { type: 'string', value: 'qore' },
+      source: { type: 'string', value: 'sub run() { print("hello"); }' },
+    },
+    options: {
+      lang: {
+        type: 'string',
+        ui_type: 'string',
+        display_name: 'Language',
+        allowed_values: [
+          { display_name: 'Qore', value: { type: 'string', value: 'qore' } },
+          { display_name: 'Python', value: { type: 'string', value: 'python' } },
+          { display_name: 'Java', value: { type: 'string', value: 'java' } },
+        ],
+      },
+      source: {
+        type: 'string',
+        ui_type: 'code-editor',
+        display_name: 'Source Code',
+        // The feature under test: the `language` prop of the code-editor
+        // renderer is sourced from sibling `lang`'s current value at
+        // render time. No `on_change` refetch — instant prop forwarding.
+        inherit_props: { language: 'lang' },
+      },
+    },
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    // Initial state: lang = "qore" → editor renderer receives language="qore"
+    await waitFor(
+      () =>
+        expect(canvas.getByTestId('code-editor-language')).toHaveTextContent('syntax: qore'),
+      { timeout: 5000 }
+    );
+
+    // Change lang → python via the select; the code-editor's `language`
+    // prop should re-resolve and the visible "syntax:" tag should update
+    // without any extra clicks or refetches.
+    const langField = (
+      canvasElement.querySelectorAll('.system-option') as NodeListOf<HTMLElement>
+    )[0];
+    const langSelectTrigger = within(langField).getByText('Qore');
+    await userEvent.click(langSelectTrigger);
+    const pythonItem = await within(document.body).findByText('Python');
+    await userEvent.click(pythonItem);
+
+    await waitFor(
+      () =>
+        expect(canvas.getByTestId('code-editor-language')).toHaveTextContent('syntax: python'),
+      { timeout: 5000 }
+    );
+  },
+};
+
 export const DependantsResetWhenParentChanges: Story = {
   args: {
     minColumnWidth: '300px',

--- a/src/components/form/engine/FormEngine.tsx
+++ b/src/components/form/engine/FormEngine.tsx
@@ -131,6 +131,37 @@ export interface IFormValidityData {
   invalidFields: IFormFieldValidityData[];
 }
 
+/**
+ * Resolve a field's `inherit_props` map against the current available
+ * options, producing a `{ propName: siblingValue }` hash suitable for
+ * spreading onto the field's renderer.
+ *
+ * For each entry `<prop-name-on-renderer> -> <sibling-field-name>`, the
+ * sibling's current value (`availableOptions[siblingName]?.value`) is
+ * forwarded under the receiving prop name. Missing siblings emit
+ * `undefined`, which the renderer's prop type can treat as "no hint".
+ *
+ * Designed to be JSON-pure: no closures, no transformations. Renderers
+ * decide how to use the forwarded value (e.g. the consumer-injected
+ * `code-editor` renderer maps a `language: "qore"` prop to its
+ * highlighter mode).
+ *
+ * Mirrored in qorus-ide `src/components/Field/systemOptions.tsx`; keep
+ * the two in sync (see qorus-ide's `.claude/CLAUDE.md`).
+ */
+const resolveInheritProps = (
+  inheritProps: Record<string, string> | undefined,
+  availableOptions: TQorusForm | undefined
+): Record<string, unknown> => {
+  if (!inheritProps || !availableOptions) return {};
+  const out: Record<string, unknown> = {};
+  for (const propName in inheritProps) {
+    const siblingName = inheritProps[propName];
+    out[propName] = (availableOptions[siblingName] as IQorusFormField | undefined)?.value;
+  }
+  return out;
+};
+
 const NegativeColorEffect: any = {
   gradient: {
     colors: { 0: 'danger', 100: 'danger:darken:2' },
@@ -1633,6 +1664,17 @@ export const FormEngine = ({
           <TemplateField
             fluid
             {...(options?.[optionName] as any)}
+            // qorus#347-followup: resolve the field's `inherit_props` against
+            // the CURRENT sibling values, threading each entry as a top-level
+            // prop. Each `<prop-name>: <sibling-field-name>` mapping copies
+            // the sibling's value (read from `availableOptions[name].value`)
+            // onto the rendered field's renderer — e.g. a code-editor with
+            // `inherit_props: { language: 'lang' }` picks up the live `lang`
+            // value as a `language` prop without a schema refetch. Spread
+            // AFTER `{...options?.[optionName]}` so the runtime value wins
+            // over any schema-defined default of the same key. Mirrored in
+            // qorus-ide's `systemOptions.tsx`; see the CLAUDE.md rule there.
+            {...resolveInheritProps(options?.[optionName]?.inherit_props, availableOptions)}
             // Propagate compact so an arg_schema field renders a COMPACT sub-form
             // (consistent with the parent) rather than the classic FormEngine.
             compact={compact}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1441,10 +1441,10 @@
     use-context-selector "^1.4.1"
     zustand "^5.0.3"
 
-"@qoretechnologies/ts-toolkit@^0.5.78":
-  version "0.5.78"
-  resolved "https://registry.yarnpkg.com/@qoretechnologies/ts-toolkit/-/ts-toolkit-0.5.78.tgz#18b7385bccc2cb3dac78de5206512668b1026bb2"
-  integrity sha512-mD/5ONx4vcuXR3zeYc66jKgSLmX7HHnCSqbbmHiC4CQJUBz6IMZEMaLYp7EvP8W0jr/muN5pH2G9TOXCzqKyaQ==
+"@qoretechnologies/ts-toolkit@^0.5.80":
+  version "0.5.80"
+  resolved "https://registry.yarnpkg.com/@qoretechnologies/ts-toolkit/-/ts-toolkit-0.5.80.tgz#925fe878448dfd13ed32d958d893acdbb2b84ace"
+  integrity sha512-L/DyQyDnz9WydCgzsVwwFruCu2hbq23LmRkO2T6d0fDVkfmRL8xYEiBMbJ/Qdiow/MOnFPEyTY7p5Yd6aFESsA==
   dependencies:
     "@qoretechnologies/reqraft" "^0.7.0"
     async "^3.2.4"


### PR DESCRIPTION
## Summary

A field can declare `inherit_props: { <propName>: <siblingFieldName> }`
(added to `IQorusFormFieldSchemaBase` in ts-toolkit — see sibling PR)
and FormEngine resolves each entry at render time: it reads the named
sibling's current value from `availableOptions` and threads it as a
runtime prop of the same name onto the field's renderer.

Distinct from `on_change: ['refetch']` (server round-trip to reshape
the schema). `inherit_props` is purely render-time prop forwarding —
fast, JSON-safe, and the receiving renderer decides how to use the
value.

## Canonical use case

A `source` field rendered by a host-injected `code-editor`
(`componentOverrides`) whose syntax highlighting tracks a sibling
`lang` picker:

```ts
{
  source: {
    ui_type: 'code-editor',
    inherit_props: { language: 'lang' },
  },
  lang: { ui_type: 'string', default_value: 'qore', allowed_values: [...] },
}
```

Flipping `lang` from `qore` to `python` makes the code-editor's
`language` prop re-resolve next render — no refetch.

## Implementation

- `resolveInheritProps(inheritProps, availableOptions)` — pure helper
  that walks the map and returns `{ propName: siblingValue }`. Missing
  siblings emit `undefined` so the renderer's prop type can treat it
  as "no hint."
- Result spread into `<TemplateField>` AFTER the schema spread so the
  runtime sibling value wins over any same-named schema default.

## Story

`FormEngine/OptionInheritsRenderPropFromSibling` demonstrates the
canonical case end-to-end. A `CodeEditorStandin` componentOverride
(textarea + visible "syntax: <language>" tag) plus a `lang` picker;
interaction test confirms changing `lang` updates the editor's
`language` prop without a refetch.

## Depends on

- ts-toolkit PR adding `inherit_props` to `IQorusFormFieldSchemaBase`

## Mirror in qorus-ide

Per qorus-ide's `.claude/CLAUDE.md`, the same forwarding logic must
also land in qorus-ide's `systemOptions.tsx` until FormEngine fully
replaces it. The qorus-ide PR description will reference this PR.

## Test plan

- [x] Story `FormEngine/OptionInheritsRenderPropFromSibling` — manual + `play` interaction test confirms language flips qore -> python without a refetch
- [ ] `yarn test:storybook` (run by CI / reviewer once ts-toolkit publishes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)