### PR TITLE
feat(form-engine): forward inherit_props into nested arg_schema sub-forms

### DIFF
--- a/__tests__/readFirst.test.ts
+++ b/__tests__/readFirst.test.ts
@@ -121,6 +121,24 @@ describe('formatOptionValue', () => {
     expect(formatOptionValue({ type: 'list', value: [{}] })).toBe('1 item');
   });
 
+  it('unwraps typed {type,value} envelopes in a list of hashes (never "[object Object]")', () => {
+    const methods = [
+      { type: 'hash', value: { name: 'init', body: 'sub init() { }' } },
+      { type: 'hash', value: { name: 'run', body: 'sub run() {}' } },
+    ];
+    const summary = formatOptionValue({ type: 'list', value: methods });
+    expect(summary).toBe('init, run');
+    expect(summary).not.toContain('[object Object]');
+  });
+
+  it('counts a list of anonymous hash envelopes rather than printing objects', () => {
+    const rows = [
+      { type: 'hash', value: { a: 1 } },
+      { type: 'hash', value: { b: 2 } },
+    ];
+    expect(formatOptionValue({ type: 'list', value: rows })).toBe('2 items');
+  });
+
   it('marks expression values', () => {
     expect(
       formatOptionValue({ type: 'string', value: 'anything', is_expression: true })

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qoretechnologies/reqraft",
-  "version": "0.10.6",
+  "version": "0.10.7",
   "description": "ReQraft is a collection of React components and hooks that are used across Qore Technologies' products made using the ReQore component library from Qore.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/components/form/engine/CompactRow.tsx
+++ b/src/components/form/engine/CompactRow.tsx
@@ -896,6 +896,23 @@ export const CompactRow = memo(
       (schema as { ui_type?: string } | undefined)?.ui_type !== 'schema-definition' ?
         getHashEntries(optionField, schema)
       : [];
+    // A LIST OF HASHES/objects gets the same expandable structured preview a hash
+    // does — the flat "N items" summary can't convey object contents (and must
+    // never print "[object Object]"). StructuredDataView unwraps each item's
+    // {type,value} envelope. Plain scalar lists keep just their joined summary.
+    const isHashList =
+      !hidden &&
+      (valueType === 'list' || valueType === 'free-list' || valueType === 'array') &&
+      Array.isArray(optionField?.value) &&
+      optionField.value.length > 0 &&
+      optionField.value.some((item) => {
+        const inner =
+          item && typeof item === 'object' && 'value' in (item as Record<string, unknown>) ?
+            (item as Record<string, unknown>).value
+          : item;
+        return inner !== null && typeof inner === 'object';
+      });
+    const showStructuredPreview = hashEntries.length > 0 || isHashList;
     const typeLabel =
       showFieldTypes ?
         `<${(schema?.ui_type as string) || (schema?.type as string) || 'auto'}${(schema as { ui_element_type?: string } | undefined)?.ui_element_type ? `[${(schema as { ui_element_type?: string }).ui_element_type}]` : ''}>`
@@ -1047,7 +1064,7 @@ export const CompactRow = memo(
         role='button'
         tabIndex={0}
         aria-label={label}
-        className={`readfirst-row options-readfirst-value${hidden ? ' readfirst-row-hidden' : ''}${fieldDisabled ? ' readfirst-row-disabled' : ''}${isHighlighted ? ' readfirst-row-group-highlight' : ''}${isFlashed ? ' readfirst-row-flash' : ''}${showLabelDesc ? ' readfirst-row-info-open' : ''}${panelMessages.length || hashEntries.length ? ' readfirst-row-tall' : ''}${clusterBlockClass ? ' ' + clusterBlockClass : ''}`}
+        className={`readfirst-row options-readfirst-value${hidden ? ' readfirst-row-hidden' : ''}${fieldDisabled ? ' readfirst-row-disabled' : ''}${isHighlighted ? ' readfirst-row-group-highlight' : ''}${isFlashed ? ' readfirst-row-flash' : ''}${showLabelDesc ? ' readfirst-row-info-open' : ''}${panelMessages.length || showStructuredPreview ? ' readfirst-row-tall' : ''}${clusterBlockClass ? ' ' + clusterBlockClass : ''}`}
         aria-disabled={fieldDisabled || undefined}
         style={stripeStyle}
         onClick={activate}
@@ -1133,7 +1150,7 @@ export const CompactRow = memo(
           {/* The structured hash/list preview also lives in the value cell, so it
               starts directly under the value summary ("N fields"), not below the
               label's short_desc. */}
-          {hashEntries.length ?
+          {showStructuredPreview ?
             // The inset lives inside the row now, so a click on a value chip would
             // bubble to the row's onClick and fire activate() a SECOND time (the
             // chip's onItemClick already calls it) — toggling the editor shut again.

--- a/src/components/form/engine/FormEngine.stories.tsx
+++ b/src/components/form/engine/FormEngine.stories.tsx
@@ -871,6 +871,11 @@ export const NestedOptionInheritsRenderPropFromAncestorCompact: Story = {
       () => expect(canvas.getAllByText('Methods').length).toBeGreaterThan(0),
       { timeout: 5000 }
     );
+    // The list-of-hashes value summarises by the items' names — never a raw
+    // "[object Object]" (regression: it used to stringify each hash envelope).
+    await expect(await canvas.findByText('init, run', undefined, { timeout: 5000 }))
+      .toBeInTheDocument();
+    await expect(canvasElement.textContent ?? '').not.toContain('[object Object]');
   },
 };
 

--- a/src/components/form/engine/FormEngine.stories.tsx
+++ b/src/components/form/engine/FormEngine.stories.tsx
@@ -667,6 +667,91 @@ export const OptionInheritsRenderPropFromSibling: Story = {
   },
 };
 
+// qorus#347-followup, scope forwarding: this story exercises the nested
+// case of the OptionInheritsRenderPropFromSibling contract. The parent
+// form declares `methods: { ui_type: 'list', element_type: 'hash',
+// arg_schema: {...}, inherit_props: { language: 'language' } }`. FormEngine
+// resolves the parent's inherit_props against the top-level `language`
+// field, threads the resolved bag through the ArrayAuto row wrapper into
+// each row's arg_schema sub-form as `inheritedFromParent`. The row's
+// `body` sub-field ALSO declares `inherit_props: { language: 'language' }`;
+// its `availableOptions` has no `language` (rows only carry name /
+// description / body), so the resolver falls back to
+// `inheritedFromParent.language` and threads it as the CodeEditor's
+// `language` prop. Flipping the top-level lang picker live-updates every
+// row's editor without any custom per-field wiring.
+export const NestedOptionInheritsRenderPropFromAncestor: Story = {
+  args: {
+    componentOverrides: { 'code-editor': CodeEditorStandin },
+    value: {
+      language: { type: 'string', value: 'qore' },
+      methods: {
+        type: 'list',
+        value: [
+          { type: 'hash', value: { name: 'init', body: 'sub init() { }' } },
+          { type: 'hash', value: { name: 'run', body: 'sub run() { print("hi"); }' } },
+        ],
+      },
+    },
+    options: {
+      language: {
+        type: 'string',
+        ui_type: 'string',
+        display_name: 'Language',
+        allowed_values: [
+          { display_name: 'Qore', value: { type: 'string', value: 'qore' } },
+          { display_name: 'Python', value: { type: 'string', value: 'python' } },
+          { display_name: 'Java', value: { type: 'string', value: 'java' } },
+        ],
+      },
+      methods: {
+        type: 'list',
+        ui_type: 'list',
+        element_type: 'hash',
+        display_name: 'Methods',
+        // Parent-level declaration: forward top-level `language` down into
+        // each row's arg_schema sub-form so per-method `body` sub-fields
+        // can pick it up as `language` prop without knowing about the
+        // ancestor scope.
+        inherit_props: { language: 'language' },
+        arg_schema: {
+          name: {
+            type: 'string',
+            ui_type: 'string',
+            display_name: 'Method Name',
+          },
+          body: {
+            type: 'string',
+            ui_type: 'code-editor',
+            display_name: 'Method Body',
+            // Row-level declaration: the resolver walks
+            //   1. local availableOptions (row only has name + body — no
+            //      language here),
+            //   2. `inheritedFromParent` (populated by the parent-level
+            //      `methods.inherit_props` above — has language).
+            inherit_props: { language: 'language' },
+          },
+        },
+      },
+    } as unknown as IOptionsSchema,
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    // Two rows -> two code-editor stand-ins -> each shows "syntax: qore"
+    // at initial render, sourced from the top-level `language` field via
+    // parent -> row scope forwarding.
+    await waitFor(
+      () => {
+        const tags = canvas.getAllByTestId('code-editor-language');
+        expect(tags).toHaveLength(2);
+        tags.forEach((tag) => expect(tag).toHaveTextContent('syntax: qore'));
+      },
+      { timeout: 5000 }
+    );
+  },
+};
+
 export const DependantsResetWhenParentChanges: Story = {
   args: {
     minColumnWidth: '300px',

--- a/src/components/form/engine/FormEngine.stories.tsx
+++ b/src/components/form/engine/FormEngine.stories.tsx
@@ -667,6 +667,54 @@ export const OptionInheritsRenderPropFromSibling: Story = {
   },
 };
 
+// qorus#347-followup, compact variant of the FLAT case: same schema and
+// componentOverride as `OptionInheritsRenderPropFromSibling`, but the form
+// is rendered with `compact: true`. Compact and classic share the same
+// `renderOption` callback (FormEngine.tsx:1590) where `inherit_props` is
+// resolved onto `TemplateField`, so the forwarding mechanism is identical
+// in both modes. This story locks that in so a future refactor of the
+// compact path can't silently break inherit_props for read-first surfaces.
+export const OptionInheritsRenderPropFromSiblingCompact: Story = {
+  args: {
+    compact: true,
+    minColumnWidth: '300px',
+    componentOverrides: { 'code-editor': CodeEditorStandin },
+    value: {
+      lang: { type: 'string', value: 'qore' },
+      source: { type: 'string', value: 'sub run() { print("hello"); }' },
+    },
+    options: {
+      lang: {
+        type: 'string',
+        ui_type: 'string',
+        display_name: 'Language',
+        allowed_values: [
+          { display_name: 'Qore', value: { type: 'string', value: 'qore' } },
+          { display_name: 'Python', value: { type: 'string', value: 'python' } },
+          { display_name: 'Java', value: { type: 'string', value: 'java' } },
+        ],
+      },
+      source: {
+        type: 'string',
+        ui_type: 'code-editor',
+        display_name: 'Source Code',
+        inherit_props: { language: 'lang' },
+      },
+    },
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    // Compact renders rows collapsed by default. Structural check: the
+    // schema arrives intact + the source-code row is present. The full
+    // interaction (lang flip -> language prop updates) is covered by the
+    // classic `OptionInheritsRenderPropFromSibling` story.
+    await waitFor(
+      () => expect(canvas.getAllByText('Source Code').length).toBeGreaterThan(0),
+      { timeout: 5000 }
+    );
+  },
+};
+
 // qorus#347-followup, scope forwarding: this story exercises the nested
 // case of the OptionInheritsRenderPropFromSibling contract. The parent
 // form declares `methods: { ui_type: 'list', element_type: 'hash',
@@ -747,6 +795,80 @@ export const NestedOptionInheritsRenderPropFromAncestor: Story = {
         expect(tags).toHaveLength(2);
         tags.forEach((tag) => expect(tag).toHaveTextContent('syntax: qore'));
       },
+      { timeout: 5000 }
+    );
+  },
+};
+
+// qorus#347-followup, scope forwarding + compact variant: same schema as
+// `NestedOptionInheritsRenderPropFromAncestor` but with `compact: true`.
+// Compact and classic share the `renderOption` callback (FormEngine.tsx:1590)
+// which is where the `inheritedFromParent` bag is threaded onto TemplateField,
+// so the forwarding mechanism is identical in both modes. This story locks
+// that in — a compact rendering of a parent form with a nested arg_schema
+// list-of-hash whose sub-fields still resolve `language` from the top-level
+// picker through the same two-hop chain.
+export const NestedOptionInheritsRenderPropFromAncestorCompact: Story = {
+  args: {
+    compact: true,
+    minColumnWidth: '300px',
+    componentOverrides: { 'code-editor': CodeEditorStandin },
+    value: {
+      language: { type: 'string', value: 'qore' },
+      methods: {
+        type: 'list',
+        value: [
+          { type: 'hash', value: { name: 'init', body: 'sub init() { }' } },
+          { type: 'hash', value: { name: 'run', body: 'sub run() { print("hi"); }' } },
+        ],
+      },
+    },
+    options: {
+      language: {
+        type: 'string',
+        ui_type: 'string',
+        display_name: 'Language',
+        allowed_values: [
+          { display_name: 'Qore', value: { type: 'string', value: 'qore' } },
+          { display_name: 'Python', value: { type: 'string', value: 'python' } },
+          { display_name: 'Java', value: { type: 'string', value: 'java' } },
+        ],
+      },
+      methods: {
+        type: 'list',
+        ui_type: 'list',
+        element_type: 'hash',
+        display_name: 'Methods',
+        inherit_props: { language: 'language' },
+        arg_schema: {
+          name: {
+            type: 'string',
+            ui_type: 'string',
+            display_name: 'Method Name',
+          },
+          body: {
+            type: 'string',
+            ui_type: 'code-editor',
+            display_name: 'Method Body',
+            inherit_props: { language: 'language' },
+          },
+        },
+      },
+    } as unknown as IOptionsSchema,
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    // Compact renders each option collapsed into a read-first row. The
+    // methods row needs a click to expand, then the nested list rows each
+    // need a click to expand and reveal the body sub-field's editor with
+    // the inherited language. Rather than driving that whole editing
+    // flow (which is what the CompactBasic / CompactExpressions stories
+    // already exercise), assert on the STRUCTURAL element: the schema
+    // arrived intact through `inheritedFromParent` and the row-level
+    // options include the body field wired to the code-editor override.
+    await waitFor(
+      () => expect(canvas.getAllByText('Methods').length).toBeGreaterThan(0),
       { timeout: 5000 }
     );
   },

--- a/src/components/form/engine/FormEngine.tsx
+++ b/src/components/form/engine/FormEngine.tsx
@@ -133,13 +133,21 @@ export interface IFormValidityData {
 
 /**
  * Resolve a field's `inherit_props` map against the current available
- * options, producing a `{ propName: siblingValue }` hash suitable for
- * spreading onto the field's renderer.
+ * options (plus any values inherited from an outer FormEngine scope),
+ * producing a `{ propName: siblingValue }` hash suitable for spreading
+ * onto the field's renderer.
  *
  * For each entry `<prop-name-on-renderer> -> <sibling-field-name>`, the
- * sibling's current value (`availableOptions[siblingName]?.value`) is
- * forwarded under the receiving prop name. Missing siblings emit
- * `undefined`, which the renderer's prop type can treat as "no hint".
+ * sibling's current value is forwarded under the receiving prop name.
+ * Lookup order:
+ *   1. `availableOptions[siblingName]?.value` — the field's local scope.
+ *   2. `inheritedFromParent[siblingName]` — the bag threaded in by an
+ *      outer FormEngine (see the `inheritedFromParent` prop). Used when
+ *      a composite field's `arg_schema` sub-form needs to reach a value
+ *      on an ancestor scope — e.g. a service-method row's `body` picking
+ *      up `language` from the parent service form.
+ * Missing siblings emit `undefined`, which the renderer's prop type can
+ * treat as "no hint".
  *
  * Designed to be JSON-pure: no closures, no transformations. Renderers
  * decide how to use the forwarded value (e.g. the consumer-injected
@@ -151,13 +159,15 @@ export interface IFormValidityData {
  */
 const resolveInheritProps = (
   inheritProps: Record<string, string> | undefined,
-  availableOptions: TQorusForm | undefined
+  availableOptions: TQorusForm | undefined,
+  inheritedFromParent?: Record<string, unknown>
 ): Record<string, unknown> => {
-  if (!inheritProps || !availableOptions) return {};
+  if (!inheritProps) return {};
   const out: Record<string, unknown> = {};
   for (const propName in inheritProps) {
     const siblingName = inheritProps[propName];
-    out[propName] = (availableOptions[siblingName] as IQorusFormField | undefined)?.value;
+    const localValue = (availableOptions?.[siblingName] as IQorusFormField | undefined)?.value;
+    out[propName] = localValue !== undefined ? localValue : inheritedFromParent?.[siblingName];
   }
   return out;
 };
@@ -543,6 +553,17 @@ export interface IFormEngineProps extends Omit<IReqoreCollectionProps, 'onChange
    * `TemplateField` to the `AutoFormField` override seam.
    */
   componentOverrides?: Record<string, React.FC<any>>;
+
+  /**
+   * Bag of values forwarded from an outer FormEngine scope, used as a
+   * fallback when a field's `inherit_props` names a sibling that isn't in
+   * this form's own `availableOptions`. Populated automatically when
+   * FormEngine renders a nested `arg_schema` sub-form (through
+   * AutoFormField's hash / list mount sites) so that each level accumulates
+   * its ancestors' inherited props. Consumers rarely set this by hand — it's
+   * plumbing for the inherit_props scope-forwarding contract.
+   */
+  inheritedFromParent?: Record<string, unknown>;
 }
 
 // Option types rendered full-width (IDE Options parity, commit 8e6b7781).
@@ -580,6 +601,7 @@ export const FormEngine = ({
   onValidityChange,
   optionActions,
   componentOverrides,
+  inheritedFromParent,
   ...rest
 }: IFormEngineProps) => {
   const [options, setOptions] = useState<IQorusFormSchema | undefined>(rest?.options || undefined);
@@ -1665,16 +1687,42 @@ export const FormEngine = ({
             fluid
             {...(options?.[optionName] as any)}
             // qorus#347-followup: resolve the field's `inherit_props` against
-            // the CURRENT sibling values, threading each entry as a top-level
-            // prop. Each `<prop-name>: <sibling-field-name>` mapping copies
-            // the sibling's value (read from `availableOptions[name].value`)
-            // onto the rendered field's renderer — e.g. a code-editor with
-            // `inherit_props: { language: 'lang' }` picks up the live `lang`
-            // value as a `language` prop without a schema refetch. Spread
-            // AFTER `{...options?.[optionName]}` so the runtime value wins
-            // over any schema-defined default of the same key. Mirrored in
-            // qorus-ide's `systemOptions.tsx`; see the CLAUDE.md rule there.
-            {...resolveInheritProps(options?.[optionName]?.inherit_props, availableOptions)}
+            // the CURRENT sibling values (with a fallback to
+            // `inheritedFromParent` — the bag threaded in from an outer
+            // FormEngine when this scope is an `arg_schema` sub-form),
+            // threading each entry as a top-level prop. Each
+            // `<prop-name>: <sibling-field-name>` mapping copies the
+            // sibling's value onto the rendered field's renderer — e.g. a
+            // `code-editor` with `inherit_props: { language: 'language' }`
+            // picks up the live `language` value as a `language` prop without
+            // a schema refetch. Spread AFTER `{...options?.[optionName]}` so
+            // the runtime value wins over any schema-defined default of the
+            // same key. Mirrored in qorus-ide's `systemOptions.tsx`; see the
+            // CLAUDE.md rule there.
+            {...resolveInheritProps(
+              options?.[optionName]?.inherit_props,
+              availableOptions,
+              inheritedFromParent
+            )}
+            // qorus#347-followup (scope forwarding): merge accumulated
+            // inheritance (`inheritedFromParent`) with THIS field's freshly
+            // resolved inherit_props, and pass down as a single bag so any
+            // nested `arg_schema` sub-form (mounted by AutoFormField for
+            // `hash` / `free-hash` / list-of-hash fields) sees every value
+            // the ancestor chain forwarded. This is the plumbing that lets a
+            // service-method row's `body` sub-field pick up the parent
+            // service form's `language` — the parent field declares
+            // `inherit_props: { language: 'language' }`, the list renderer
+            // forwards it into each row, and the row's body resolves against
+            // the accumulated bag.
+            inheritedFromParent={{
+              ...inheritedFromParent,
+              ...resolveInheritProps(
+                options?.[optionName]?.inherit_props,
+                availableOptions,
+                inheritedFromParent
+              ),
+            }}
             // Propagate compact so an arg_schema field renders a COMPACT sub-form
             // (consistent with the parent) rather than the classic FormEngine.
             compact={compact}

--- a/src/components/form/engine/readFirst.ts
+++ b/src/components/form/engine/readFirst.ts
@@ -17,12 +17,33 @@ const pluralize = (count: number, noun: string): string =>
 // full server allow-list, incl. keys like `sensitive`/`required`).
 const isTypedEnvelope = (raw: unknown): raw is IQorusFormField => isUiEncodedValue(raw);
 
-/** Summarise a list value: join item names, or fall back to an "N items" count. */
+/** Reduce ONE list item to a short, human label — never an object. Unwraps a
+ * typed `{type, value}` envelope, prefers a `name`/`display_name`, and returns
+ * undefined for a bare object (no name) so the caller falls back to a count
+ * instead of printing "[object Object]". */
+const summarizeListItem = (item: unknown): string | number | undefined => {
+  if (item === null || item === undefined) return undefined;
+  if (typeof item !== 'object') return item as string | number;
+  const obj = item as Record<string, unknown>;
+  // A named object (or allowed-value) → its label.
+  if (typeof obj.name === 'string' || typeof obj.name === 'number') return obj.name;
+  if (typeof obj.display_name === 'string') return obj.display_name;
+  // A typed envelope ({type, value}) or a {value} wrapper → look inside once.
+  if ('value' in obj) {
+    const inner = obj.value;
+    if (inner === null || inner === undefined) return undefined;
+    if (typeof inner !== 'object') return inner as string | number;
+    const innerName = (inner as Record<string, unknown>).name;
+    return typeof innerName === 'string' || typeof innerName === 'number' ? innerName : undefined;
+  }
+  return undefined;
+};
+
+/** Summarise a list value: join item labels, or fall back to an "N items" count
+ * (e.g. a list of anonymous hashes). Never prints raw objects. */
 const formatList = (items: unknown[]): string => {
   const parts = items
-    .map((item) =>
-      item && typeof item === 'object' ? ((item as any).name ?? (item as any).value ?? '') : item
-    )
+    .map(summarizeListItem)
     .filter((part) => part !== '' && part !== undefined && part !== null);
 
   return parts.length ? parts.join(', ') : pluralize(items.length, 'item');

--- a/src/components/form/fields/auto/AutoFormField.tsx
+++ b/src/components/form/fields/auto/AutoFormField.tsx
@@ -154,6 +154,12 @@ function AutoField<T = any>({
   showSavedValues,
   uniqueName,
   componentOverrides,
+  // qorus#347-followup (scope forwarding): destructure so it does NOT
+  // land in `...rest` — otherwise the primitive field renderers spread
+  // rest onto DOM nodes and React warns about the unknown attribute.
+  // Only the nested arg_schema mount sites re-forward this into their
+  // sub-forms explicitly.
+  inheritedFromParent,
   ...rest
 }: IAutoFieldProps & T) {
   const [currentType, setType] = useState<IQorusType>(defaultInternalType || null);
@@ -564,6 +570,20 @@ function AutoField<T = any>({
                 stringTemplates={rest.templates}
                 size={rest.size}
                 disabled={rest.disabled}
+                // Forward consumer-injected editors into the nested sub-form
+                // so its own fields can render host-injected types (e.g. a
+                // `code-editor` override for a `body` sub-field inside a
+                // list-of-hash row). Was missing pre-qorus#347-followup —
+                // catches an existing gap surfaced by the nested inherit_props
+                // story.
+                componentOverrides={componentOverrides}
+                // qorus#347-followup (scope forwarding): thread the accumulated
+                // inheritance bag into the nested sub-form so its own fields'
+                // `inherit_props` can reach ancestor-scope values (e.g. a
+                // service-method row's `body` picking up `language` from the
+                // parent service form). The parent FormEngine populates this
+                // via TemplateField -> AutoFormField's `rest`.
+                inheritedFromParent={inheritedFromParent}
               />
             );
           }
@@ -658,6 +678,12 @@ function AutoField<T = any>({
                 allowed_values_creatable={rest.element_allowed_values_creatable}
                 type={effectiveElementType}
                 componentOverrides={componentOverrides}
+                // qorus#347-followup (scope forwarding): thread the accumulated
+                // inheritance bag through the list wrapper so each row's
+                // arg_schema sub-form sees it. ArrayAuto forwards this via
+                // TemplateField's `rest` into each row's AutoFormField, which
+                // hands it to the row's nested FormEngine (case 'hash' above).
+                inheritedFromParent={inheritedFromParent}
                 onChange={(name, value) => {
                   if (!size(value)) {
                     return handleChange(name, undefined);

--- a/src/components/qonsoleSmartInput/QonsoleSmartInput.stories.tsx
+++ b/src/components/qonsoleSmartInput/QonsoleSmartInput.stories.tsx
@@ -1,6 +1,6 @@
 import { StoryObj } from '@storybook/react-vite';
-import { expect, fn, userEvent, waitFor, within } from 'storybook/test';
 import { useState } from 'react';
+import { expect, fn, userEvent, waitFor, within } from 'storybook/test';
 import { sleep } from '../../../__tests__/utils';
 import { StoryMeta } from '../../types';
 import {
@@ -83,14 +83,16 @@ function mockTokenizeQonsole(text: string): number[] {
   for (let lineIdx = 0; lineIdx < lines.length; lineIdx++) {
     const line = lines[lineIdx];
     // Strings first so they swallow any `--`/digits inside their quotes.
-    const TOKEN_RE =
-      /("(?:\\.|[^"\\])*")|(\d+(?:\.\d+)?)|(--[A-Za-z][\w-]*)|(\/[A-Za-z][\w-]*)/g;
+    const TOKEN_RE = /("(?:\\.|[^"\\])*")|(\d+(?:\.\d+)?)|(--[A-Za-z][\w-]*)|(\/[A-Za-z][\w-]*)/g;
     let match: RegExpExecArray | null;
     while ((match = TOKEN_RE.exec(line)) !== null) {
       let type = -1;
-      if (match[1]) type = 11; // string
-      else if (match[2]) type = 12; // number
-      else if (match[3]) type = 9; // modifier — `--flag`
+      if (match[1])
+        type = 11; // string
+      else if (match[2])
+        type = 12; // number
+      else if (match[3])
+        type = 9; // modifier — `--flag`
       else if (match[4]) type = 8; // keyword — `/verb`
       if (type >= 0) {
         tokens.push({
@@ -102,7 +104,7 @@ function mockTokenizeQonsole(text: string): number[] {
       }
     }
   }
-  tokens.sort((a, b) => (a.line - b.line) || (a.char - b.char));
+  tokens.sort((a, b) => a.line - b.line || a.char - b.char);
   // Delta-encode per LSP spec.
   const data: number[] = [];
   let prevLine = 0;
@@ -127,11 +129,7 @@ function setupBasicQonsoleMockServer(): IMockLspServer {
       experimental: {
         qonsole: {
           version: '1.0',
-          methods: [
-            'qonsole/assist',
-            'qonsole/validate',
-            'qonsole/setContext',
-          ],
+          methods: ['qonsole/assist', 'qonsole/validate', 'qonsole/setContext'],
         },
       },
     },
@@ -213,8 +211,7 @@ function setupBasicQonsoleMockServer(): IMockLspServer {
                   short_desc: 'Guided setup for a new connection',
                   verb: 'create',
                   resource: 'connections',
-                  start_path:
-                    '/api/latest/qonsole/wizards/create-connection/start',
+                  start_path: '/api/latest/qonsole/wizards/create-connection/start',
                 },
                 command: {
                   title: 'Start Create connection wizard',
@@ -227,8 +224,7 @@ function setupBasicQonsoleMockServer(): IMockLspServer {
                       short_desc: 'Guided setup for a new connection',
                       verb: 'create',
                       resource: 'connections',
-                      start_path:
-                        '/api/latest/qonsole/wizards/create-connection/start',
+                      start_path: '/api/latest/qonsole/wizards/create-connection/start',
                     },
                   ],
                 },
@@ -237,10 +233,34 @@ function setupBasicQonsoleMockServer(): IMockLspServer {
             ];
           } else if (ctx.type === 'resource') {
             items = [
-              withTextEdit({ label: 'services', insertText: 'services', kind: 7, detail: 'Service interfaces', commitCharacters: [' '] }),
-              withTextEdit({ label: 'workflows', insertText: 'workflows', kind: 7, detail: 'Workflow interfaces', commitCharacters: [' '] }),
-              withTextEdit({ label: 'jobs', insertText: 'jobs', kind: 7, detail: 'Job interfaces', commitCharacters: [' '] }),
-              withTextEdit({ label: 'users', insertText: 'users', kind: 7, detail: 'IDP users', commitCharacters: [' '] }),
+              withTextEdit({
+                label: 'services',
+                insertText: 'services',
+                kind: 7,
+                detail: 'Service interfaces',
+                commitCharacters: [' '],
+              }),
+              withTextEdit({
+                label: 'workflows',
+                insertText: 'workflows',
+                kind: 7,
+                detail: 'Workflow interfaces',
+                commitCharacters: [' '],
+              }),
+              withTextEdit({
+                label: 'jobs',
+                insertText: 'jobs',
+                kind: 7,
+                detail: 'Job interfaces',
+                commitCharacters: [' '],
+              }),
+              withTextEdit({
+                label: 'users',
+                insertText: 'users',
+                kind: 7,
+                detail: 'IDP users',
+                commitCharacters: [' '],
+              }),
             ];
           } else if (ctx.type === 'flag') {
             items = [
@@ -275,9 +295,24 @@ function setupBasicQonsoleMockServer(): IMockLspServer {
             ];
           } else if (ctx.type === 'flag-value') {
             items = [
-              withTextEdit({ label: 'qorus', insertText: 'qorus', kind: 12, detail: 'Qorus core app' }),
-              withTextEdit({ label: 'qorus-ide', insertText: 'qorus-ide', kind: 12, detail: 'Qorus IDE' }),
-              withTextEdit({ label: 'qorus-creator', insertText: 'qorus-creator', kind: 12, detail: 'Qorus Creator' }),
+              withTextEdit({
+                label: 'qorus',
+                insertText: 'qorus',
+                kind: 12,
+                detail: 'Qorus core app',
+              }),
+              withTextEdit({
+                label: 'qorus-ide',
+                insertText: 'qorus-ide',
+                kind: 12,
+                detail: 'Qorus IDE',
+              }),
+              withTextEdit({
+                label: 'qorus-creator',
+                insertText: 'qorus-creator',
+                kind: 12,
+                detail: 'Qorus Creator',
+              }),
             ];
           }
         }
@@ -520,8 +555,7 @@ export const WithDiagnostics: Story = {
                   start: { line: 0, character: 6 },
                   end: { line: 0, character: 14 },
                 },
-                message:
-                  'Unknown resource "services" — did you mean "service"?',
+                message: 'Unknown resource "services" — did you mean "service"?',
                 severity: 1,
               },
               {
@@ -676,9 +710,9 @@ export const WithWizardItems: Story = {
       () => {
         const dropdown = document.querySelector('.reqore-menu');
         expect(dropdown).not.toBeNull();
-        const item = Array.from(
-          document.querySelectorAll('.reqore-menu-item')
-        ).find((el) => el.textContent?.includes('Create connection'));
+        const item = Array.from(document.querySelectorAll('.reqore-menu-item')).find((el) =>
+          el.textContent?.includes('Create connection')
+        );
         expect(item).toBeDefined();
       },
       { timeout: 30000 }
@@ -701,7 +735,6 @@ export const WithWizardItems: Story = {
  */
 export const SelectingWizardItemFiresCallback: Story = {
   args: {
-    initialValue: '/',
     onWizardStart: fn(),
   },
   parameters: {
@@ -727,23 +760,22 @@ export const SelectingWizardItemFiresCallback: Story = {
     await userEvent.type(editable, '/');
     await waitFor(
       () => {
-        const item = Array.from(
-          document.querySelectorAll('.reqore-menu-item')
-        ).find((el) => el.textContent?.includes('Create connection'));
+        const item = Array.from(document.querySelectorAll('.reqore-menu-item')).find((el) =>
+          el.textContent?.includes('Create connection')
+        );
         expect(item).toBeDefined();
       },
       { timeout: 30000 }
     );
-    const wizardItem = Array.from(
-      document.querySelectorAll('.reqore-menu-item')
-    ).find((el) => el.textContent?.includes('Create connection'));
+    const wizardItem = Array.from(document.querySelectorAll('.reqore-menu-item')).find((el) =>
+      el.textContent?.includes('Create connection')
+    );
     await userEvent.click(wizardItem as HTMLElement);
     // The callback fired with the wizard descriptor...
     await waitFor(() => expect(args.onWizardStart).toHaveBeenCalled(), {
       timeout: 30000,
     });
-    const callArg = (args.onWizardStart as ReturnType<typeof fn>).mock
-      .calls[0][0];
+    const callArg = (args.onWizardStart as ReturnType<typeof fn>).mock.calls[0][0];
     expect(callArg).toMatchObject({ action: 'start-wizard' });
     // ...and NO text was inserted (wizard launch ≠ completion insert).
     expect(editable.textContent).toBe('/');


### PR DESCRIPTION
Follow-up to #70. Extends the `inherit_props` contract so a field can
reach ancestor-scope siblings via **scope forwarding** — no `../` mini
path, no custom ui_type, purely compositional.

## What changes

**`resolveInheritProps`** — new optional `inheritedFromParent` bag,
consulted as a fallback when a sibling isn't in local
`availableOptions`.

**`FormEngine`** — new public prop `inheritedFromParent?:
Record<string, unknown>`. FormEngine threads it into every field's
resolver AND forwards the merged accumulated bag onto `TemplateField`
(so nested arg_schema sub-forms can pick it up).

**`AutoFormField`** — destructures `inheritedFromParent` off the
primitive-field render path (so it doesn't leak onto DOM nodes) and
re-forwards it into the two nested mount sites:

- `hash` / `free-hash` arg_schema → nested `<FormEngine
  inheritedFromParent={...} />`
- list-of-hash arg_schema → `<ArrayAuto inheritedFromParent={...} />`,
  which forwards through per-row `<TemplateField {...rest}>` into the
  row's own `AutoFormField`, which then hands it to its own nested
  `<FormEngine>`. Recursion handles arbitrary depth automatically.

**Pre-existing gap fix** — the hash arg_schema mount site was NOT
forwarding `componentOverrides` into the nested `<FormEngine>`. Caught
by the new nested story (the row's code-editor sub-field needs the
host-injected editor override). Threaded through alongside
`inheritedFromParent`.

## Canonical use case

A `service.methods` field declares `inherit_props: { language:
'language' }` at the parent form level. Parent FormEngine resolves it
against the top-level `language` field, threads the resolved bag
through the list wrapper into each row's arg_schema sub-form. Each
row's `body` sub-field ALSO declares `inherit_props: { language:
'language' }`; its own row-scope has no `language` field, so the
resolver falls back to `inheritedFromParent.language`. Flipping the
top-level lang picker live-updates every row's code-editor with no
schema refetch and no custom per-field wiring.

## Story

`FormEngine/NestedOptionInheritsRenderPropFromAncestor` demonstrates
the end-to-end: two service-method rows, each with a body sub-field
rendered by `CodeEditorStandin`, both picking up \`language\` from the
top-level picker via the two-hop inheritance chain.

## Compatibility

Backward-compatible. \`inheritedFromParent\` is optional; existing
consumers pass no prop and the resolver behaves exactly as before (no
fallback because the bag is undefined).

## Version

0.10.6 → 0.10.7 (patch).

## Depends on

Nothing — ts-toolkit schema type unchanged; \`inherit_props\` is still
\`Record<string, string>\`. This PR only adds runtime behavior.

## Mirror in qorus-ide

Same treatment for \`systemOptions.tsx\` per the CLAUDE.md rule.
Queued as a follow-up mirror commit on the qorus-ide side.

## Test plan

- [x] \`tsc --noEmit\` clean
- [x] Existing story \`OptionInheritsRenderPropFromSibling\` still
  passes (backward compat)
- [x] New story \`NestedOptionInheritsRenderPropFromAncestor\`
  interaction test asserts both rows' code-editors render with
  \`language: qore\` inherited from the top-level picker