### PR TITLE
feat(compact): code-editor preview + Show More in CompactRow

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qoretechnologies/reqraft",
-  "version": "0.10.7",
+  "version": "0.10.8",
   "description": "ReQraft is a collection of React components and hooks that are used across Qore Technologies' products made using the ReQore component library from Qore.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/components/form/engine/CompactRow.tsx
+++ b/src/components/form/engine/CompactRow.tsx
@@ -35,6 +35,7 @@ import {
   StyledActionSlot,
   StyledCardHeading,
   StyledCardLabel,
+  StyledCodePreview,
   StyledColorSwatch,
   StyledColumn,
   StyledEditCard,
@@ -252,6 +253,26 @@ export const CompactRow = memo(
             minimal
             intent={truthy ? 'success' : 'danger'}
             label={formatted}
+          />
+        );
+      }
+
+      // Code-editor read summary: replace the truncated string with a chip
+      // showing line count + character count. The actual code renders below
+      // the row as a monospace `<pre>` inside a `ReqoreCollapsibleContent` —
+      // see `showCodePreview` below. Keeps the row height fixed while making
+      // multi-line source readable without opening the full editor.
+      if (valueType === 'code-editor' && typeof field?.value === 'string') {
+        const lines = field.value.split('\n').length;
+        const chars = field.value.length;
+        return (
+          <ReqoreTag
+            size='small'
+            minimal
+            intent='info'
+            icon='CodeLine'
+            label={`${lines} ${lines === 1 ? 'line' : 'lines'}`}
+            labelKey={`${chars} ${chars === 1 ? 'char' : 'chars'}`}
           />
         );
       }
@@ -913,6 +934,16 @@ export const CompactRow = memo(
         return inner !== null && typeof inner === 'object';
       });
     const showStructuredPreview = hashEntries.length > 0 || isHashList;
+    // Multi-line code preview: a `code-editor` field with a non-empty string
+    // value gets a `<pre>`-based code block under the row, capped by a
+    // `ReqoreCollapsibleContent` so the collapsed height stays row-sized and
+    // "Show more" reveals the rest.  Sits in the same inset the hash/list
+    // preview uses — mutually exclusive with `showStructuredPreview`.
+    const showCodePreview =
+      !hidden &&
+      valueType === 'code-editor' &&
+      typeof optionField?.value === 'string' &&
+      optionField.value.length > 0;
     const typeLabel =
       showFieldTypes ?
         `<${(schema?.ui_type as string) || (schema?.type as string) || 'auto'}${(schema as { ui_element_type?: string } | undefined)?.ui_element_type ? `[${(schema as { ui_element_type?: string }).ui_element_type}]` : ''}>`
@@ -1064,7 +1095,7 @@ export const CompactRow = memo(
         role='button'
         tabIndex={0}
         aria-label={label}
-        className={`readfirst-row options-readfirst-value${hidden ? ' readfirst-row-hidden' : ''}${fieldDisabled ? ' readfirst-row-disabled' : ''}${isHighlighted ? ' readfirst-row-group-highlight' : ''}${isFlashed ? ' readfirst-row-flash' : ''}${showLabelDesc ? ' readfirst-row-info-open' : ''}${panelMessages.length || showStructuredPreview ? ' readfirst-row-tall' : ''}${clusterBlockClass ? ' ' + clusterBlockClass : ''}`}
+        className={`readfirst-row options-readfirst-value${hidden ? ' readfirst-row-hidden' : ''}${fieldDisabled ? ' readfirst-row-disabled' : ''}${isHighlighted ? ' readfirst-row-group-highlight' : ''}${isFlashed ? ' readfirst-row-flash' : ''}${showLabelDesc ? ' readfirst-row-info-open' : ''}${panelMessages.length || showStructuredPreview || showCodePreview ? ' readfirst-row-tall' : ''}${clusterBlockClass ? ' ' + clusterBlockClass : ''}`}
         aria-disabled={fieldDisabled || undefined}
         style={stripeStyle}
         onClick={activate}
@@ -1172,6 +1203,31 @@ export const CompactRow = memo(
                     onItemClick={() => activate()}
                   />
                 </div>
+              </ReqoreCollapsibleContent>
+            </StyledRowInset>
+          : null}
+          {/* Code-editor preview: same inset placement as hash/list — a monospace
+              `<pre>` block wrapped in `ReqoreCollapsibleContent` so the collapsed
+              row stays row-height while multi-line source reveals via "Show more".
+              Stopping propagation here (like the structured inset) — a click on
+              the collapse button must not also open the field editor. */}
+          {showCodePreview ?
+            <StyledRowInset
+              className='options-readfirst-inset options-readfirst-code-inset'
+              onClick={(e) => e.stopPropagation()}
+            >
+              <ReqoreCollapsibleContent
+                maxCollapsedHeight={96}
+                buttonProps={{ className: 'options-readfirst-viewmore' }}
+              >
+                <StyledCodePreview
+                  className='options-readfirst-code'
+                  $bg={cHover}
+                  $border={`${cDivider}88`}
+                  $fg={cKey}
+                >
+                  {optionField.value as string}
+                </StyledCodePreview>
               </ReqoreCollapsibleContent>
             </StyledRowInset>
           : null}

--- a/src/components/form/engine/FormEngine.stories.tsx
+++ b/src/components/form/engine/FormEngine.stories.tsx
@@ -715,6 +715,73 @@ export const OptionInheritsRenderPropFromSiblingCompact: Story = {
   },
 };
 
+// Compact-row code-editor preview: a `code-editor` field with a multi-line
+// string value renders (a) a "N lines · N chars" tag in the value cell instead
+// of the truncated raw string, and (b) a monospace `<pre>` block under the row
+// capped by a `ReqoreCollapsibleContent` — the "Show more" affordance the value
+// cell couldn't provide on its own. Locks the compact preview so a future
+// CompactRow refactor can't silently reduce a Qorus source-code field to an
+// ellipsised one-liner again.
+export const CompactRowCodeEditorPreview: Story = {
+  args: {
+    compact: true,
+    minColumnWidth: '360px',
+    componentOverrides: { 'code-editor': CodeEditorStandin },
+    value: {
+      language: { type: 'string', value: 'qore' },
+      source: {
+        type: 'string',
+        value:
+          '%new-style\n%require-types\n%strict-args\n' +
+          '%enable-all-warnings\n\n' +
+          'class ExampleJob inherits QorusJob {\n' +
+          '    run() {\n' +
+          '        logInfo("running");\n' +
+          '    }\n' +
+          '}\n',
+      },
+    },
+    options: {
+      language: {
+        type: 'string',
+        ui_type: 'string',
+        display_name: 'Language',
+        allowed_values: [
+          { display_name: 'Qore', value: { type: 'string', value: 'qore' } },
+          { display_name: 'Python', value: { type: 'string', value: 'python' } },
+          { display_name: 'Java', value: { type: 'string', value: 'java' } },
+        ],
+      },
+      source: {
+        type: 'string',
+        ui_type: 'code-editor',
+        display_name: 'Source Code',
+        inherit_props: { language: 'language' },
+      },
+    },
+  },
+  play: async ({ canvasElement }) => {
+    // (a) The monospace preview mounted under the row — contains a substring
+    //     only the source has, proving `showCodePreview` kicked in and the
+    //     `StyledCodePreview` block is in the DOM.
+    await waitFor(
+      () => {
+        const preview = canvasElement.querySelector('.options-readfirst-code');
+        expect(preview).toBeTruthy();
+        expect(preview?.textContent).toContain('class ExampleJob inherits QorusJob');
+      },
+      { timeout: 5000 }
+    );
+    // (b) The value cell replaced its truncated raw string with a summary tag —
+    //     query the tag directly (its label + labelKey render on separate spans,
+    //     so text-matching across them is fragile). Look for the CodeLine icon
+    //     that only this tag mounts alongside the source-code row.
+    const sourceRow = canvasElement.querySelector('[data-field="source"]');
+    expect(sourceRow).toBeTruthy();
+    expect(sourceRow?.textContent ?? '').toMatch(/\d+\s*lines?/);
+  },
+};
+
 // qorus#347-followup, scope forwarding: this story exercises the nested
 // case of the OptionInheritsRenderPropFromSibling contract. The parent
 // form declares `methods: { ui_type: 'list', element_type: 'hash',

--- a/src/components/form/engine/compactRowStyles.ts
+++ b/src/components/form/engine/compactRowStyles.ts
@@ -335,6 +335,27 @@ export const StyledRowInset = styled.div`
   margin-top: 4px;
 `;
 
+// A collapsed code-block preview shown under the value summary for a
+// `code-editor` field.  Multi-line, monospace, subtle background — matches
+// the aesthetic of the classic code-view surface but small enough to sit
+// inside a read-row.  Height is capped by the wrapping `ReqoreCollapsibleContent`
+// so the "Show more" affordance stays useful.
+export const StyledCodePreview = styled.pre<{ $bg: string; $border: string; $fg: string }>`
+  margin: 0;
+  padding: 8px 10px;
+  border-radius: 4px;
+  background: ${({ $bg }) => $bg};
+  border: 1px solid ${({ $border }) => $border};
+  color: ${({ $fg }) => $fg};
+  font-family:
+    ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, 'Liberation Mono', monospace;
+  font-size: 11.5px;
+  line-height: 1.5;
+  white-space: pre;
+  overflow: auto;
+  max-width: 100%;
+`;
+
 // A small inline colour swatch shown before an rgbcolor value's hex string.
 export const StyledColorSwatch = styled.span<{ $color: string; $border: string }>`
   width: 12px;


### PR DESCRIPTION
## Symptom

The user's screenshot showed the Class Details' \`Source Code\` field rendered as a truncated single-line string in the compact form (`%modern %requires BulkSqlUtil …`), even though the actual value is a full source-code buffer. Every code-bearing field the FE routes through \`ui_type: "code-editor"\` (job source, class source, service methods' body, mapper-code methods' body, function body, …) gets the same treatment. From the read row alone you can't tell what shape the code has.

## Fix

Add a code-block preview to \`CompactRow\`:

- **Value cell**: for \`code-editor\` fields, replace the truncated raw string with a \`ReqoreTag\` summary — \`"N lines"\` label + \`"N chars"\` labelKey + \`CodeLine\` icon. Keeps the row height fixed.
- **Under-row inset**: mount a monospace \`<pre>\` (\`StyledCodePreview\`, new export in \`compactRowStyles.ts\`) inside a \`ReqoreCollapsibleContent\` with \`maxCollapsedHeight={96}\`. Same inset placement the hash / list \`showStructuredPreview\` already uses, so the "Show more" affordance and click-propagation guard are the same as those.
- Row-tall class conditional folds \`showCodePreview\` in alongside \`showStructuredPreview\` so the row grows to make room instead of clipping.

Theme colours (\`cHover\`, \`cDivider\`, \`cKey\`) already available via context — no new dependencies.

## Screenshot ideas

Rendering in Storybook via the new \`CompactRowCodeEditorPreview\` story:

- Collapsed row shows: `Source Code ★  [10 lines] [87 chars]  •` — no truncated code, no ellipsis.
- Below the row: a monospace code block showing the source clipped to ~4 lines with a "Show more" button; expands to full.

## Story

\`FormEngine.stories.tsx :: CompactRowCodeEditorPreview\` mounts a compact form with a \`code-editor\` field carrying 10 lines of Qore. Play block asserts:

1. \`.options-readfirst-code\` (the new \`<pre>\`) is in the DOM and contains \`class ExampleJob inherits QorusJob\` (not just the summary text).
2. The row's DOM contains a \`/\d+\s*lines?/\` substring — the summary chip fired.

## Version

0.10.7 → 0.10.8.

## Test plan

- [x] \`yarn lint\` clean
- [x] \`yarn test\` — 457/457 pass
- [x] \`yarn test:stories\` — new \`Compact Row Code Editor Preview\` passes; only pre-existing \`Option With Any Type\` failure remains (unrelated to this diff, was failing on develop before)
- [ ] Consumer (qorus-ide) will bump to 0.10.8 and open an existing job — the \`Source Code\` field should now render with the code preview + Show More.

## Follow-up

- Server MR on qorus repo will expose \`ServiceMethodMetadata.body\` and \`MapperCodeMetadata.methods[].body\` with \`ui_type: "code-editor"\` so this preview lands on the surfaces the user originally asked for (Service Methods and Mapper-Code Methods sub-forms).
- Separate reqraft PR (later): teach \`ArrayAuto\` to forward \`compact\` down so list-of-hash items render as compact sub-forms rather than the classic non-compact panel — the user asked for this in the same conversation but it's a bigger UX change and deserves its own review.