### PR TITLE
chore(stories): 100% description coverage

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qoretechnologies/reqraft",
-  "version": "0.10.10",
+  "version": "0.10.11",
   "description": "ReQraft is a collection of React components and hooks that are used across Qore Technologies' products made using the ReQore component library from Qore.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/components/dpqlEditor/DpqlEditor.stories.tsx
+++ b/src/components/dpqlEditor/DpqlEditor.stories.tsx
@@ -511,7 +511,15 @@ const meta = {
 export default meta;
 export type Story = StoryObj<typeof meta>;
 
-export const Empty: Story = {};
+export const Empty: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story: 'Renders the DpqlEditor with no value — the editor mounts empty and ready for input.',
+      },
+    },
+  },
+};
 
 /**
  * No chips / templates — just a valid DPQL literal expression so we can
@@ -524,17 +532,41 @@ export const WithPlainText: Story = {
   args: {
     value: '1 == 1 && "hello" != "world"',
   },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders the DpqlEditor with a plain DPQL literal expression — no field references or templates, so the editor mounts as plain text with no tag chips.',
+      },
+    },
+  },
 };
 
 export const WithFieldReference: Story = {
   args: {
     value: '@name == "Alice"',
   },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders the DpqlEditor with an @name field reference — the editor mounts with a tag chip for the field and the literal string operand.',
+      },
+    },
+  },
 };
 
 export const WithTemplateVariable: Story = {
   args: {
     value: 'contains("$local:input", "es")',
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders the DpqlEditor with a contains() call whose first argument is a $local:input template — the template renders as a tag chip inside the call.',
+      },
+    },
   },
 };
 
@@ -543,6 +575,14 @@ export const WithMixedContent: Story = {
     // DPQL uses `&&` for logical AND (not SQL's `AND`). See
     // qore-2/design/dpql-syntax.md §"Logical Operators".
     value: '@name == $data:{1.name} && @age > $config:min_age',
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders the DpqlEditor with mixed content — two @field references, two $data / $config templates and the DPQL "&&" logical operator between them, each rendered as its own chip or token.',
+      },
+    },
   },
 };
 
@@ -1014,6 +1054,14 @@ export const ReadOnly: Story = {
     value: '@name == "Alice"',
     readOnly: true,
   },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders the DpqlEditor with a valued expression but readOnly enabled — the field chip and literal render but the editor cannot be edited.',
+      },
+    },
+  },
 };
 
 /**
@@ -1131,6 +1179,14 @@ export const CanTypeText: Story = {
     value: '',
     onChange: fn(),
   },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders the empty DpqlEditor and types "hello" into it — the editor accepts the plain text and fires onChange.',
+      },
+    },
+  },
   play: async ({ canvasElement, args }) => {
     const canvas = within(canvasElement);
 
@@ -1152,6 +1208,14 @@ export const LspCompletionRoundtrip: Story = {
   args: {
     value: '',
     onChange: fn(),
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders the empty DpqlEditor and types the "@" trigger — the LSP receives a textDocument/completion request against a dpql:// document URI and the dropdown mounts with the canned @name / @status / @age items.',
+      },
+    },
   },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
@@ -1199,7 +1263,15 @@ export const LspCompletionRoundtrip: Story = {
  * single physical connection and a single `initialize` handshake.
  */
 export const TwoEditorsOneConnection: Story = {
-  parameters: { chromatic: { disable: true } },
+  parameters: {
+    chromatic: { disable: true },
+    docs: {
+      description: {
+        story:
+          'Renders two DpqlEditor instances side by side — both share a single WebSocket via LspSharedConnection and each opens its own document URI, so the server sees one initialize but two didOpen notifications.',
+      },
+    },
+  },
   render: () => (
     <>
       <DpqlEditorWithState value='name' />

--- a/src/components/form/engine/FormEngine.stories.tsx
+++ b/src/components/form/engine/FormEngine.stories.tsx
@@ -152,6 +152,14 @@ type Story = StoryObj<typeof meta>;
 // stories
 
 export const Basic: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders FormEngine over the shared basic-schema fixture — every option and value the classic layout exercises (booleans, strings with values, templates, invalid types) is present.',
+      },
+    },
+  },
   args: {
     minColumnWidth: '300px',
     options: getOptions(),
@@ -188,6 +196,14 @@ export const Basic: Story = {
 
 export const Small: Story = {
   ...Basic,
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders the Basic FormEngine at size=small — the same fixture but with the compact size preset applied to every control.',
+      },
+    },
+  },
   args: {
     ...Basic.args,
     size: 'small',
@@ -196,6 +212,14 @@ export const Small: Story = {
 
 export const InvalidShownOnly: Story = {
   ...Basic,
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders the Basic FormEngine, then clicks the invalid-fields message chip in the header — only the invalid options stay visible.',
+      },
+    },
+  },
   play: async (args) => {
     await Basic.play!(args);
     await fireEvent.click(document.querySelector('.reqore-message')!);
@@ -211,6 +235,14 @@ export const InvalidShownOnly: Story = {
 };
 
 export const Optional: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders FormEngine with only the optional half of the basic schema — the More Options Available collapsible box is shown but not opened.',
+      },
+    },
+  },
   args: {
     minColumnWidth: '300px',
     options: getOptions(true),
@@ -218,6 +250,14 @@ export const Optional: Story = {
 };
 
 export const OptionalOpened: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders FormEngine with only the optional half of the basic schema, then clicks the More Options Available banner — the optional fields drop down into the form.',
+      },
+    },
+  },
   args: {
     minColumnWidth: '300px',
     options: getOptions(true),
@@ -236,6 +276,14 @@ export const OptionalOpened: Story = {
 
 export const FocusedEditing: Story = {
   ...Basic,
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders the Basic FormEngine, hovers an option and clicks its fullscreen action — the Focused Editing modal opens over that single field.',
+      },
+    },
+  },
   play: async (args) => {
     await Basic.play!(args);
     await userEvent.hover(document.querySelectorAll('.system-option')[0]);
@@ -246,6 +294,14 @@ export const FocusedEditing: Story = {
 
 export const DescriptionIsShown: Story = {
   ...Basic,
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders the Basic FormEngine and clicks the Option with description label — the help panel opens with the option\'s long-form description.',
+      },
+    },
+  },
   play: async ({ canvasElement, ...rest }) => {
     const canvas = within(canvasElement);
     await Basic.play!({ canvasElement, ...rest });
@@ -256,6 +312,14 @@ export const DescriptionIsShown: Story = {
 };
 
 export const ValueCanBeRemoved: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders FormEngine holding a text option and a file option, both with values. Hovering each row and clicking its remove action clears the value and marks the row as revertable.',
+      },
+    },
+  },
   args: {
     options: {
       textOption: {
@@ -300,6 +364,14 @@ export const ValueCanBeRemoved: Story = {
 
 export const ChangeCanBeReverted: Story = {
   ...ValueCanBeRemoved,
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders the ValueCanBeRemoved fixture after both values are removed, then clicks the per-row revert action — the file value comes back.',
+      },
+    },
+  },
   play: async (args) => {
     await ValueCanBeRemoved.play!(args);
     await _testsClickButton({ selector: '.options-item-revert', nth: 1 });
@@ -309,6 +381,14 @@ export const ChangeCanBeReverted: Story = {
 
 export const AllChangesCanBeReverted: Story = {
   ...ValueCanBeRemoved,
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders the ValueCanBeRemoved fixture after both values are removed, then clicks the form-level revert action — the entire form goes back to its original values.',
+      },
+    },
+  },
   play: async (args) => {
     await ValueCanBeRemoved.play!(args);
     await _testsClickButton({ selector: '.fields-revert' });
@@ -318,6 +398,14 @@ export const AllChangesCanBeReverted: Story = {
 
 export const WithTypesShown: Story = {
   ...Basic,
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders the Basic FormEngine and clicks the show-types header action — every option label picks up its Qore type badge (e.g. <rgbcolor>).',
+      },
+    },
+  },
   play: async (args) => {
     await Basic.play!(args);
     await _testsClickButton({ selector: '.fields-show-types' });
@@ -326,6 +414,14 @@ export const WithTypesShown: Story = {
 };
 
 export const WithRequiredGroups: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders FormEngine with five options that all belong to one required_groups group — every row mounts and the group\'s one-of-required indicator is shown.',
+      },
+    },
+  },
   args: {
     minColumnWidth: '300px',
     options: TestOptionsWithRequiredGroups,
@@ -338,6 +434,14 @@ export const WithRequiredGroups: Story = {
 };
 
 export const WithRequiredGroupsFulfilled: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders the required-group schema with one of the group\'s options already filled — the group\'s one-of-required indicator marks the group as satisfied.',
+      },
+    },
+  },
   args: {
     minColumnWidth: '300px',
     options: TestOptionsWithRequiredGroups,
@@ -353,6 +457,14 @@ export const WithRequiredGroupsFulfilled: Story = {
 };
 
 export const OptionDependsOnOptionOrAnotherOption: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders FormEngine with a required option that depends on Required Option 2 OR Required Option 5 — the field is disabled until either dependency is filled, then the disabled note clears.',
+      },
+    },
+  },
   args: {
     minColumnWidth: '300px',
     options: {
@@ -383,6 +495,14 @@ export const OptionDependsOnOptionOrAnotherOption: Story = {
 };
 
 export const OptionDependsOnOptionInRequiredGroup: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders FormEngine with a required option that depends on Required Option 2 alone — filling Required Option 2 clears the disabled note.',
+      },
+    },
+  },
   args: {
     minColumnWidth: '300px',
     options: {
@@ -413,6 +533,14 @@ export const OptionDependsOnOptionInRequiredGroup: Story = {
 };
 
 export const OptionalWithValues: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders FormEngine with only the optional half of the basic schema plus pre-existing values — the optional fields are already populated and the More Options Available banner is hidden.',
+      },
+    },
+  },
   args: {
     minColumnWidth: '300px',
     options: getOptions(true),
@@ -425,6 +553,14 @@ export const OptionalWithValues: Story = {
 };
 
 export const OptionWithAnyType: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders four options typed as any with templates enabled — empty ones show a Select Template dropdown, the pre-typed number field renders as a Number input and the operator can switch types via the More menu.',
+      },
+    },
+  },
   args: {
     options: {
       optionWithAnyType: {
@@ -491,6 +627,14 @@ export const OptionWithAnyType: Story = {
 };
 
 export const NonExistentOptionsFiltered: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders FormEngine with a value that carries three fields but a schema that declares only two — the extra option is filtered out and onChange fires without it.',
+      },
+    },
+  },
   args: {
     value: {
       option1: { type: 'long-string', value: 'option1' },
@@ -526,6 +670,14 @@ export const NonExistentOptionsFiltered: Story = {
 };
 
 export const OptionsWithOnChangeTriggerEvents: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders FormEngine with an option that declares on_change: [\'refetch\']. Editing the field fires onChange with meta.events set to [\'refetch\'] so the host can re-fetch dependent options.',
+      },
+    },
+  },
   args: {
     value: {
       optionWithRefetchAndReset: { type: 'long-string', value: 'option1' },
@@ -610,6 +762,14 @@ const CodeEditorStandin = ({
 // a sibling `lang` picker, so flipping the picker live-changes the
 // editor's syntax highlighting with no refetch.
 export const OptionInheritsRenderPropFromSibling: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders FormEngine with a code-editor field that declares inherit_props: { language: \'lang\' } — the sibling language picker feeds the editor\'s language prop at render time, and flipping the picker live-updates the syntax without any refetch.',
+      },
+    },
+  },
   args: {
     componentOverrides: { 'code-editor': CodeEditorStandin },
     value: {
@@ -675,6 +835,14 @@ export const OptionInheritsRenderPropFromSibling: Story = {
 // in both modes. This story locks that in so a future refactor of the
 // compact path can't silently break inherit_props for read-first surfaces.
 export const OptionInheritsRenderPropFromSiblingCompact: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders the OptionInheritsRenderPropFromSibling schema with compact=true — the same inherit_props forwarding runs through the compact renderer.',
+      },
+    },
+  },
   args: {
     compact: true,
     minColumnWidth: '300px',
@@ -723,6 +891,14 @@ export const OptionInheritsRenderPropFromSiblingCompact: Story = {
 // CompactRow refactor can't silently reduce a Qorus source-code field to an
 // ellipsised one-liner again.
 export const CompactRowCodeEditorPreview: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders a compact-mode code-editor row over a multi-line Qore source value — the value cell replaces the truncated string with a lines/chars summary tag and a collapsible monospace preview mounts under the row.',
+      },
+    },
+  },
   args: {
     compact: true,
     minColumnWidth: '360px',
@@ -796,6 +972,14 @@ export const CompactRowCodeEditorPreview: Story = {
 // `language` prop. Flipping the top-level lang picker live-updates every
 // row's editor without any custom per-field wiring.
 export const NestedOptionInheritsRenderPropFromAncestor: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders FormEngine with a list-of-hash methods option whose row sub-schema declares inherit_props: { language: \'language\' } — the parent-level forwarding threads the top-level language down to every row\'s code-editor body sub-field.',
+      },
+    },
+  },
   args: {
     componentOverrides: { 'code-editor': CodeEditorStandin },
     value: {
@@ -876,6 +1060,14 @@ export const NestedOptionInheritsRenderPropFromAncestor: Story = {
 // list-of-hash whose sub-fields still resolve `language` from the top-level
 // picker through the same two-hop chain.
 export const NestedOptionInheritsRenderPropFromAncestorCompact: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders the NestedOptionInheritsRenderPropFromAncestor schema with compact=true — the compact renderer summarises the list-of-hash rows as \'init, run\' rather than [object Object].',
+      },
+    },
+  },
   args: {
     compact: true,
     minColumnWidth: '300px',
@@ -947,6 +1139,14 @@ export const NestedOptionInheritsRenderPropFromAncestorCompact: Story = {
 };
 
 export const DependantsResetWhenParentChanges: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders FormEngine with two dependent options plus two has-dependents parents. Changing the parent\'s value clears every dependent\'s value while leaving the unrelated sibling untouched.',
+      },
+    },
+  },
   args: {
     minColumnWidth: '300px',
     options: {
@@ -1023,6 +1223,14 @@ export const DependantsResetWhenParentChanges: Story = {
 };
 
 export const ValueIsFixedWhenDefaultValueDoesNotMatchAndReadOnlyIsTrue: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders FormEngine with a read-only option whose stored value differs from its default_value — the value is auto-corrected to the default at mount and the wrong value never renders.',
+      },
+    },
+  },
   args: {
     minColumnWidth: '300px',
     options: {
@@ -1066,6 +1274,14 @@ export const ValueIsFixedWhenDefaultValueDoesNotMatchAndReadOnlyIsTrue: Story = 
 };
 
 export const DoesNotCauseInfiniteRerenders: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders FormEngine with a refetch-triggering parent and a list-of-hash dependent — the schema mounts cleanly and adding a new list item does not cause the form to re-render infinitely.',
+      },
+    },
+  },
   args: {
     minColumnWidth: '300px',
     options: {
@@ -1126,6 +1342,14 @@ export const DoesNotCauseInfiniteRerenders: Story = {
 };
 
 export const AllowedValuesOptionWithTemplateValueShowsWarning: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders FormEngine with an allowed_values option that holds a template value ($local:test) instead of one of the allowed values — the option shows a warning that the template value is outside the allowed set.',
+      },
+    },
+  },
   args: {
     minColumnWidth: '300px',
     options: {
@@ -1168,6 +1392,12 @@ export const AllowedValuesOptionWithTemplateValueShowsWarning: Story = {
 export const OnValidityChange: Story = {
   // chromatic off: async validity-callback timing.
   parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders FormEngine wired to an onValidityChange callback — the callback fires with per-field validity data as the overall form validity changes.',
+      },
+    },
     chromatic: { disable: true },
   },
   args: {
@@ -1419,6 +1649,14 @@ const CompactFieldsMenuSchema: Record<string, TCompactField> = {
 };
 
 export const Compact: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders FormEngine in compact mode over the CompactSchema fixture with groups — options collapse to read-first rows grouped under labelled group headers, with formatted value summaries per row.',
+      },
+    },
+  },
   args: {
     compact: true,
     minColumnWidth: '300px',
@@ -1443,7 +1681,15 @@ export const Compact: Story = {
 };
 
 export const CompactReadOnly: Story = {
-  parameters: { chromatic: { disable: true } },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders the Compact fixture with readOnly enabled — the Draft/Ready progress badge is hidden and rows open in view (non-editable) mode.',
+      },
+    },
+    chromatic: { disable: true },
+  },
   args: {
     ...Compact.args,
     readOnly: true,
@@ -1462,6 +1708,14 @@ export const CompactReadOnly: Story = {
 };
 
 export const CompactEmpty: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders the Compact fixture with no value — all six empty fields render a dash placeholder and the four optional fields sit in the collapsed Optional box.',
+      },
+    },
+  },
   args: {
     compact: true,
     minColumnWidth: '300px',
@@ -1482,7 +1736,15 @@ export const CompactEmpty: Story = {
 // Compact mode on the EXACT shared fixture behind `Basic` — every option and
 // state the classic layout exercises.
 export const CompactBasic: Story = {
-  parameters: { chromatic: { disable: true } },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders FormEngine in compact mode over the full Basic fixture — every value renders in its read-first form (templates by name, colours as hex, hashes as field-count summaries), disabled and dependency-locked rows stay non-interactive, and the dependency lock\'s popover navigates to blockers.',
+      },
+    },
+    chromatic: { disable: true },
+  },
   args: {
     compact: true,
     minColumnWidth: '300px',
@@ -1631,7 +1893,15 @@ export const CompactBasic: Story = {
 // ($-token + resolved name). Regression cover for the review note "this should
 // show as a readonly richtext or a readonly template picker".
 export const CompactReadOnlyRichText: Story = {
-  parameters: { chromatic: { disable: true } },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders the CompactBasic fixture with readOnly enabled — opening the Rich Text row shows a non-editable Slate surface, and the Template row renders as a read-only template-picker chip showing the resolved template name (never the raw $local reference).',
+      },
+    },
+    chromatic: { disable: true },
+  },
   args: {
     ...CompactBasic.args,
     readOnly: true,
@@ -1704,6 +1974,14 @@ const ORDER_STATE_SAMPLE = {
 // Hash rows render the IDE workflow-orders `StructuredDataView` under the
 // fade/"Show more" wrapper; doubles as the raw-vs-envelope data contrast.
 export const CompactHashStructuredView: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders CompactBasic with an extra orderState hash option holding a raw payload — the hash row uses the StructuredDataView tree renderer with type-aware value cells; clicking a value chip opens the hash editor.',
+      },
+    },
+  },
   args: {
     ...CompactBasic.args,
     options: {
@@ -1802,7 +2080,15 @@ export const CompactHashStructuredView: Story = {
 // grows a Save/Discard bar, Save emits `onCommit` (gated on validity), and
 // every staged edit still emits `onChange` flagged `meta.draft`.
 export const CompactBatchedCommit: Story = {
-  parameters: { chromatic: { disable: true } },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders a valid form in commitMode=\'batched\'. Staging an edit adds the Draft chip and \'unsaved changes\' bar without committing; Save fires onCommit and clears the chips; Discard reverts the staged edit.',
+      },
+    },
+    chromatic: { disable: true },
+  },
   args: {
     compact: true,
     commitMode: 'batched',
@@ -1868,6 +2154,14 @@ export const CompactBatchedCommit: Story = {
 
 // While any field is invalid, the bar shows but Save refuses to commit.
 export const CompactBatchedCommitInvalid: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders an invalid form in commitMode=\'batched\' — staging an edit shows the unsaved-changes bar but Save is disabled and onCommit never fires.',
+      },
+    },
+  },
   args: {
     compact: true,
     commitMode: 'batched',
@@ -1903,6 +2197,14 @@ export const CompactBatchedCommitInvalid: Story = {
 // `sensitive`: the read row masks the value (and its hover title) — the secret
 // never renders as page text, in read or edit state.
 export const CompactSensitive: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders a compact form with a sensitive: true API-token field — the read row masks the value (and its hover title) and the edit input renders as type=password.',
+      },
+    },
+  },
   args: {
     compact: true,
     minColumnWidth: '300px',
@@ -1942,6 +2244,14 @@ export const CompactSensitive: Story = {
 // `rules: ['valid_identifier']` flows from the schema into validation: a bad
 // identifier marks the form invalid (banner + Draft badge).
 export const CompactValidIdentifierRule: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders a compact form with an option that carries a valid-identifier validation rule — invalid input surfaces the identifier-format error inline.',
+      },
+    },
+  },
   args: {
     compact: true,
     minColumnWidth: '300px',
@@ -1969,6 +2279,14 @@ export const CompactValidIdentifierRule: Story = {
 // Operators (filter/mapper-style forms): the `operators` prop renders the
 // operator selector + the WHERE/IS summary in the card editor.
 export const CompactOperators: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders a compact form with per-option operator support — each row shows the operator select alongside the value and the WHERE/IS summary tags.',
+      },
+    },
+  },
   args: {
     compact: true,
     minColumnWidth: '300px',
@@ -2012,7 +2330,15 @@ export const CompactOperators: Story = {
 // focusedEditing in compact: the card's fullscreen affordance opens the same
 // focused-editing modal the classic layout has, with the field's descriptions.
 export const CompactFocusedEditing: Story = {
-  parameters: { chromatic: { disable: true } },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders the compact form, opens a row and switches to focused-editing mode — the row expands into a modal-style editing surface.',
+      },
+    },
+    chromatic: { disable: true },
+  },
   args: {
     compact: true,
     minColumnWidth: '300px',
@@ -2050,7 +2376,15 @@ export const CompactFocusedEditing: Story = {
 // multi-select editor in the card.
 export const CompactMultiSelectEditing: Story = {
   // chromatic off: ends with an open multi-select editor card (live editor state).
-  parameters: { chromatic: { disable: true } },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders a compact form with a multi-select option — editing the row exposes the chip picker and multiple values can be added and removed.',
+      },
+    },
+    chromatic: { disable: true },
+  },
   args: {
     compact: true,
     minColumnWidth: '300px',
@@ -2085,7 +2419,15 @@ export const CompactMultiSelectEditing: Story = {
 
 // Field-level `sort` orders compact rows (schema declared out of order).
 export const CompactSortOrder: Story = {
-  parameters: { chromatic: { disable: true } },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders a compact form whose options carry sort ordinals — the rows render in sort order rather than schema-declaration order.',
+      },
+    },
+    chromatic: { disable: true },
+  },
   args: {
     compact: true,
     minColumnWidth: '300px',
@@ -2127,7 +2469,15 @@ export const CompactSortOrder: Story = {
 };
 
 export const CompactReadFirstEditing: Story = {
-  parameters: { chromatic: { disable: true } },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders the compact form and opens a row for editing — the row transitions from the read-first summary to the inline or card editor.',
+      },
+    },
+    chromatic: { disable: true },
+  },
   args: {
     compact: true,
     minColumnWidth: '300px',
@@ -2178,7 +2528,15 @@ export const CompactReadFirstEditing: Story = {
 // easy to keep track of. The flash is the observable signal that the panel-change
 // locate fired (the scroll itself, scrollIntoView, isn't assertable in the runner).
 export const CompactPanelChangeScroll: Story = {
-  parameters: { chromatic: { disable: true } },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders a compact form inside a scrollable panel — opening a row keeps the panel\'s scroll position pinned rather than jumping to the top.',
+      },
+    },
+    chromatic: { disable: true },
+  },
   args: {
     compact: true,
     minColumnWidth: '300px',
@@ -2229,7 +2587,15 @@ export const CompactPanelChangeScroll: Story = {
 };
 
 export const CompactRequiredOnlyAndSearch: Story = {
-  parameters: { chromatic: { disable: true } },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders a compact form with the required-only filter and the search input enabled — filtering by requirement and typing a query narrows the visible rows.',
+      },
+    },
+    chromatic: { disable: true },
+  },
   args: {
     compact: true,
     minColumnWidth: '300px',
@@ -2266,7 +2632,15 @@ export const CompactRequiredOnlyAndSearch: Story = {
 };
 
 export const CompactFieldsMenu: Story = {
-  parameters: { chromatic: { disable: true } },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders a compact form and opens the Fields menu — the menu exposes show-types, show-descriptions and required-only toggles.',
+      },
+    },
+    chromatic: { disable: true },
+  },
   args: {
     compact: true,
     minColumnWidth: '300px',
@@ -2337,7 +2711,15 @@ export const CompactFieldsMenu: Story = {
 // Toolbar ⓘ: a global toggle that reveals every field's short_desc at once,
 // without opening each row's info panel by hand.
 export const CompactDescriptionsToggle: Story = {
-  parameters: { chromatic: { disable: true } },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders a compact form and toggles show-descriptions from the Fields menu — every row picks up its short_desc / desc text under the label.',
+      },
+    },
+    chromatic: { disable: true },
+  },
   args: {
     compact: true,
     minColumnWidth: '300px',
@@ -2402,7 +2784,15 @@ export const CompactDescriptionsToggle: Story = {
 };
 
 export const CompactSearchHidden: Story = {
-  parameters: { chromatic: { disable: true } },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders a compact form with searchHidden set — the search input and header search action are hidden from the toolbar.',
+      },
+    },
+    chromatic: { disable: true },
+  },
   args: {
     compact: true,
     minColumnWidth: '300px',
@@ -2501,7 +2891,15 @@ const OAuth2ScopesSchema = {
 } as any;
 
 export const CompactListYamlField: Story = {
-  parameters: { chromatic: { disable: true } },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders a compact form with a list-of-YAML option — the row summary shows the item count and opening the row exposes the YAML editor.',
+      },
+    },
+    chromatic: { disable: true },
+  },
   args: {
     compact: true,
     minColumnWidth: '300px',
@@ -2544,7 +2942,15 @@ export const CompactListYamlField: Story = {
 // value column became `minmax(0, 1fr)` + `min-width: 0`; plus the sticky
 // completion + search + Fields toolbar.
 export const CompactOverflowAndStickyHeader: Story = {
-  parameters: { chromatic: { disable: true } },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders a compact form tall enough to scroll — the group headers stick to the top of the panel as the form scrolls under them.',
+      },
+    },
+    chromatic: { disable: true },
+  },
   // A fixed-height scroll host so the sticky behaviour is observable (and
   // testable) regardless of viewport size.
   decorators: [
@@ -2598,7 +3004,15 @@ export const CompactOverflowAndStickyHeader: Story = {
 // on_change/refetch + has_dependents flow through the same handleValueChange
 // as classic — the read-first editor must fire and reset the same way.
 export const CompactOnChangeAndDependents: Story = {
-  parameters: { chromatic: { disable: true } },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders a compact form with dependency chains — editing a parent option resets its dependents and the dependent rows re-render in their fresh state.',
+      },
+    },
+    chromatic: { disable: true },
+  },
   args: {
     compact: true,
     minColumnWidth: '300px',
@@ -2655,7 +3069,15 @@ export const CompactOnChangeAndDependents: Story = {
 };
 
 export const CompactRevertAndShowTypes: Story = {
-  parameters: { chromatic: { disable: true } },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders a compact form and exercises the per-row revert action alongside the show-types Fields menu toggle.',
+      },
+    },
+    chromatic: { disable: true },
+  },
   args: {
     compact: true,
     minColumnWidth: '300px',
@@ -2736,7 +3158,15 @@ const FieldTypeCatalogGroups: Record<string, IFormEngineGroup> = {
  */
 export const CompactExpressions: Story = {
   // chromatic off: ends with the live ExpressionField editor (Text mode) open.
-  parameters: { chromatic: { disable: true } },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders a compact form with an expression-supporting option — the row opens the ExpressionField shell with the Visual builder and the Visual/Text mode toggle.',
+      },
+    },
+    chromatic: { disable: true },
+  },
   args: {
     name: 'exprForm',
     compact: true,
@@ -2833,7 +3263,15 @@ const langImg = (color: string, letter: string): string =>
  */
 export const CompactEnumWithImages: Story = {
   // chromatic off: ends with the radio editor open in the card.
-  parameters: { chromatic: { disable: true } },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders a compact form with an enum option whose allowed values carry images — the read row shows the image alongside the label and the picker mounts the images in the collection.',
+      },
+    },
+    chromatic: { disable: true },
+  },
   args: {
     name: 'langForm',
     compact: true,
@@ -2891,7 +3329,15 @@ export const CompactEnumWithImages: Story = {
  * instead of the language radio.
  */
 export const CompactEnumRichtextValue: Story = {
-  parameters: { chromatic: { disable: true } },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders a compact form with an enum option whose value is a richtext template — the read row shows the resolved template chip rather than the raw reference.',
+      },
+    },
+    chromatic: { disable: true },
+  },
   args: {
     name: 'langForm',
     compact: true,
@@ -2971,7 +3417,15 @@ const _isRowOpen = (field: string): boolean =>
  * first — the accordion model that keeps the read-first list scannable.
  */
 export const CompactSingleExpand: Story = {
-  parameters: { chromatic: { disable: true } },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders a compact form with expandMode=\'single\' — opening one row automatically collapses whichever row was open before.',
+      },
+    },
+    chromatic: { disable: true },
+  },
   args: { name: 'expandSingle', compact: true, ...expandModeFixture },
   play: async () => {
     await waitFor(
@@ -2997,7 +3451,15 @@ export const CompactSingleExpand: Story = {
 
 /** `expandMode: 'multi'`: several rows can stay open at once (form-fill flow). */
 export const CompactMultiExpand: Story = {
-  parameters: { chromatic: { disable: true } },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders a compact form with expandMode=\'multi\' — every opened row stays open until it is explicitly done, so several editors can be on screen at once.',
+      },
+    },
+    chromatic: { disable: true },
+  },
   args: { name: 'expandMulti', compact: true, expandMode: 'multi', ...expandModeFixture },
   play: async () => {
     await waitFor(
@@ -3046,6 +3508,14 @@ const HostProvidedEditor = ({
 );
 
 export const CompactFieldTypes: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders a compact form that exercises the full catalogue of ui_type renderers — every type (string, richtext, hash, list, file, colour, byte-size, cron, connection, enum, etc.) is present with a representative value.',
+      },
+    },
+  },
   args: {
     compact: true,
     minColumnWidth: '300px',
@@ -3550,7 +4020,15 @@ const _compactExpandAllRows = async () => {
 
 export const CompactFieldTypesEditing: Story = {
   // chromatic off: every catalog editor mounts live (async) — flaky and snapshot-heavy.
-  parameters: { chromatic: { disable: true } },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders CompactFieldTypes and opens every row — the edit surface for each ui_type mounts and the row-level Clear / built-in clear affordances are wired per input.',
+      },
+    },
+    chromatic: { disable: true },
+  },
   // multi: this story expands every row at once (single-open would collapse them).
   args: { ...CompactFieldTypes.args, expandMode: 'multi' as const },
   play: async () => {
@@ -3591,6 +4069,14 @@ export const CompactFieldTypesEditing: Story = {
 // to a muted-green "Covers" / "Covered by <X>" once satisfied. Members live in
 // DIFFERENT panels to prove cross-panel linkage.
 export const CompactRequiredGroups: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders a compact form whose options belong to required_groups — the group\'s one-of-required indicator appears in the row rail and clears once any member is filled.',
+      },
+    },
+  },
   args: {
     compact: true,
     minColumnWidth: '300px',
@@ -3732,7 +4218,15 @@ const _compactTypeIntoCardRichText = async (field: string, value: string) => {
 // (`[[a, b]]`) locks the row; the lock popover renders the "any of:" group;
 // fulfilling EITHER blocker unlocks (and flashes) the dependent row.
 export const CompactOptionDependsOnOptionOrAnotherOption: Story = {
-  parameters: { chromatic: { disable: true } },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders a compact form with an option that depends on A OR B — the row is locked with a dependency popover listing both alternatives; fulfilling either unlocks the row.',
+      },
+    },
+    chromatic: { disable: true },
+  },
   args: {
     compact: true,
     minColumnWidth: '300px',
@@ -3841,7 +4335,15 @@ export const CompactOptionDependsOnOptionOrAnotherOption: Story = {
 // The dependency targets a required-group MEMBER: fulfilling it unlocks the
 // dependent row AND satisfies the group — both linkage systems on one form.
 export const CompactOptionDependsOnOptionInRequiredGroup: Story = {
-  parameters: { chromatic: { disable: true } },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders a compact form with an option that depends on a required-group member — the row locks until the required-group option is filled.',
+      },
+    },
+    chromatic: { disable: true },
+  },
   args: {
     compact: true,
     minColumnWidth: '300px',
@@ -3922,7 +4424,15 @@ export const CompactOptionDependsOnOptionInRequiredGroup: Story = {
 
 // An `any`-typed option shows its value and expands to the type-aware editor.
 export const CompactAnyType: Story = {
-  parameters: { chromatic: { disable: true } },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders a compact form with any-typed options — the read rows summarise the current value and the editor lets the operator pick the concrete type through the More menu.',
+      },
+    },
+    chromatic: { disable: true },
+  },
   args: {
     compact: true,
     minColumnWidth: '300px',
@@ -3943,7 +4453,15 @@ export const CompactAnyType: Story = {
 // A schema-level `readonly` field whose value differs from its default is fixed
 // back to the default (engine `fixOptions`); the read row shows the default.
 export const CompactReadonlyDefaultFix: Story = {
-  parameters: { chromatic: { disable: true } },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders a compact form with a read-only option whose value differs from default_value — the value auto-corrects to the default at mount without the wrong value ever rendering.',
+      },
+    },
+    chromatic: { disable: true },
+  },
   args: {
     compact: true,
     minColumnWidth: '300px',
@@ -3967,7 +4485,15 @@ export const CompactReadonlyDefaultFix: Story = {
 
 // Values for options that aren't in the schema are filtered out, not rendered.
 export const CompactNonExistentFiltered: Story = {
-  parameters: { chromatic: { disable: true } },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders a compact form with a value carrying an extra field that isn\'t in the schema — the extra field is filtered out and no row is rendered for it.',
+      },
+    },
+    chromatic: { disable: true },
+  },
   args: {
     compact: true,
     minColumnWidth: '300px',
@@ -3987,7 +4513,15 @@ export const CompactNonExistentFiltered: Story = {
 
 // A field with a long `desc` shows a help affordance that opens the help dialog.
 export const CompactHelpDialog: Story = {
-  parameters: { chromatic: { disable: true } },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders a compact form and clicks a row\'s Help action — the help dialog opens with the option\'s long-form description.',
+      },
+    },
+    chromatic: { disable: true },
+  },
   args: {
     compact: true,
     minColumnWidth: '300px',
@@ -4013,7 +4547,15 @@ export const CompactHelpDialog: Story = {
 
 // Read-first rendering is render-stable — it doesn't emit a storm of onChanges.
 export const CompactDoesNotCauseInfiniteRerenders: Story = {
-  parameters: { chromatic: { disable: true } },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders a compact form with a refetch-triggering parent and a list-of-hash dependent — mounting and interacting with the form does not trigger runaway re-renders.',
+      },
+    },
+    chromatic: { disable: true },
+  },
   args: {
     compact: true,
     minColumnWidth: '300px',
@@ -4042,7 +4584,15 @@ const loadCompactSchemaAsync = (): Promise<IQorusFormSchema> =>
 // the story earns its keep through the play test (the resolve path), not a
 // snapshot — the loading state has its own story below.
 export const CompactOptionsLoader: Story = {
-  parameters: { chromatic: { disable: true } },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders a compact form whose options are fetched via a url — the loader skeleton is shown until the schema resolves, then the compact rows mount.',
+      },
+    },
+    chromatic: { disable: true },
+  },
   args: {
     compact: true,
     minColumnWidth: '300px',
@@ -4060,6 +4610,14 @@ export const CompactOptionsLoader: Story = {
 
 // A rejected load surfaces the engine's error state instead of the form.
 export const CompactOptionsLoaderError: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders a compact form whose options fetch fails — the loader resolves into an error message rather than crashing.',
+      },
+    },
+  },
   args: {
     compact: true,
     minColumnWidth: '300px',
@@ -4080,6 +4638,14 @@ export const CompactOptionsLoaderError: Story = {
 // and the snapshot Chromatic captures. The resolve path (load → form →
 // `onOptionsLoaded`) is exercised by `CompactOptionsLoader` above.
 export const OptionsLoader: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders the classic FormEngine whose options are fetched via a url — the loader is shown until the schema resolves.',
+      },
+    },
+  },
   args: {
     minColumnWidth: '300px',
     value: CompactValue,
@@ -4198,6 +4764,14 @@ const infoDisplayArgs = {
 // The flagship "real form" story: the Basic fixture + stress fields with full
 // descriptions — how compact mode looks and feels in actual use.
 export const CompactShowcase: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders the flagship compact-mode showcase — the Basic fixture plus every stress field type across a real-form layout, used as the compact-mode reference screenshot.',
+      },
+    },
+  },
   args: infoDisplayArgs,
   play: async () => {
     await _testsWaitForText('API endpoint');
@@ -4265,6 +4839,14 @@ export const CompactShowcase: Story = {
 
 // The same stress form in a 360 px container — stacked rows, panels full-width.
 export const CompactShowcaseMobile: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders the compact showcase at a ~390px mobile viewport — the compact rows collapse into a single-column stack.',
+      },
+    },
+  },
   args: infoDisplayArgs,
   decorators: [
     (StoryComponent: React.ComponentType) => (
@@ -4284,6 +4866,14 @@ export const CompactShowcaseMobile: Story = {
 // credential pair (one provided → green node + Provided badge) and a 4-member
 // notification group (none set → violet, pending).
 export const CompactRequiredGroupRails: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders a compact form with several required_groups — each group\'s rail sits alongside its rows so the operator can see which one-of-required set the row belongs to.',
+      },
+    },
+  },
   args: {
     compact: true,
     minColumnWidth: '320px',
@@ -4358,7 +4948,15 @@ export const CompactRequiredGroupRails: Story = {
 // keeps required-group clusters contiguous (rails intact) — never interleaving
 // across groups. Regression cover for the compact sort.
 export const CompactFieldSortWithinGroups: Story = {
-  parameters: { chromatic: { disable: true } },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders a compact form with grouped options that carry sort ordinals — rows within each group render in sort order, not schema-declaration order.',
+      },
+    },
+    chromatic: { disable: true },
+  },
   args: CompactRequiredGroupRails.args,
   play: async () => {
     await _testsWaitForText('API key');
@@ -4408,6 +5006,14 @@ export const CompactFieldSortWithinGroups: Story = {
 // required-but-empty, so the engine expands the `description` row on mount and
 // its editor takes focus — no click, no DOM scraping.
 export const CompactAutoFocusFirstRequired: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders a compact form with autoFocus enabled — the first unfilled required row opens for editing automatically on mount.',
+      },
+    },
+  },
   args: {
     compact: true,
     minColumnWidth: '300px',
@@ -4480,6 +5086,14 @@ const CompactInvalidFilledValue: IOptions = {
 };
 
 export const CompactAutoFocusTargetsInvalidFilledField: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders a compact form with autoFocus enabled and a required field holding an invalid value — the autofocus targets the invalid filled field rather than the next empty required.',
+      },
+    },
+  },
   args: {
     compact: true,
     minColumnWidth: '300px',
@@ -4555,6 +5169,14 @@ const CompactNonFocusableFirstSchema: Record<string, TCompactField> = {
 const CompactNonFocusableFirstValue: IOptions = {}; // both unset → both need attention
 
 export const CompactAutoFocusNonFocusableFirstField: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders a compact form with autoFocus enabled where the first needs-attention field is a boolean (not focusable) — the autofocus skips it and opens the next focusable field instead.',
+      },
+    },
+  },
   args: {
     compact: true,
     minColumnWidth: '300px',

--- a/src/components/form/engine/FormEngineRemote.stories.tsx
+++ b/src/components/form/engine/FormEngineRemote.stories.tsx
@@ -123,6 +123,14 @@ export const SchemaFromUrl: Story = {
     name: 'remoteBasic',
     url: 'sb-remote/basic',
   },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders FormEngine with a url — the options schema is fetched from options/{url}, three fields mount with the preselected localhost default seeded and onOptionsLoaded fires with the fetched schema.',
+      },
+    },
+  },
   async beforeEach() {
     return mockFetchRoutes({ 'options/sb-remote/basic': { body: BASIC_SCHEMA } });
   },
@@ -153,6 +161,14 @@ export const OperatorsFromUrl: Story = {
       hostname: { type: 'string', value: 'qore', op: ['like'] },
     } as any,
   },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders FormEngine with both url and operatorsUrl — the operator select resolves the "like" op against the fetched operator schema and the WHERE/IS summary tags appear alongside the option.',
+      },
+    },
+  },
   async beforeEach() {
     return mockFetchRoutes({
       'options/sb-remote/search': { body: SEARCH_SCHEMA },
@@ -181,6 +197,14 @@ export const FetchFailure: Story = {
     name: 'remoteFail',
     url: 'sb-remote/fail',
   },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders FormEngine when the schema fetch returns 500 — the skeleton resolves into the "No options available" empty state instead of crashing.',
+      },
+    },
+  },
   async beforeEach() {
     return mockFetchRoutes({
       'options/sb-remote/fail': { status: 500, body: { err: 'boom' } },
@@ -201,6 +225,14 @@ export const UrlChangeResetsValue: Story = {
   args: {
     name: 'remoteSwitch',
     url: 'sb-remote/first',
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders FormEngine wired to url="first". Clicking the switch button re-points the engine to a different schema — the previous value (localhost) is dropped and the new Token field mounts.',
+      },
+    },
   },
   render(args) {
     const [url, setUrl] = useState(args.url);
@@ -256,6 +288,14 @@ export const InjectedOptionActions: Story = {
       },
     ],
   },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders FormEngine with an optionActions factory that injects a per-option AI-assist button. Hovering an option reveals the injected action next to it.',
+      },
+    },
+  },
   async play() {
     await waitFor(() => expect(optionCount()).toBe(3), { timeout: 10000 });
 
@@ -277,6 +317,14 @@ export const TemplatesFromContext: Story = {
     name: 'ctxTemplates',
     options: BASIC_SCHEMA as any,
     interfaceContext: 'sb-ctx',
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders FormEngine with an interfaceContext — useTemplates hits system/getContextData so template values are available in the schema fields.',
+      },
+    },
   },
   async beforeEach() {
     return mockFetchRoutes({

--- a/src/components/form/engine/_structuredData/StructuredDataView.stories.tsx
+++ b/src/components/form/engine/_structuredData/StructuredDataView.stories.tsx
@@ -57,6 +57,14 @@ export const WorkflowOrderData: Story = {
     // Expand deep enough that the parsed-YAML sub-tree is visible.
     defaultExpandDepth: 3,
   },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders StructuredDataView over a workflow-order payload — UI-encoded envelopes unwrap to scalars, embedded YAML strings parse into sub-trees and Qorus timestamps format to YYYY-MM-DD HH:mm:ss.SSS in the viewer\'s zone.',
+      },
+    },
+  },
   play: async () => {
     await _testsWaitForText('ORD-1002');
     await _testsWaitForText('order-process');

--- a/src/components/form/engine/variants/FormEngineVariants.stories.tsx
+++ b/src/components/form/engine/variants/FormEngineVariants.stories.tsx
@@ -59,6 +59,14 @@ type Story = StoryObj<typeof meta>;
 
 export const V1CalmTable: Story = {
   name: '1 · Calm Table',
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders the "Calm Table" compact-form variant over the shared basic schema — one of four visual candidates for the read-first FormEngine view.',
+      },
+    },
+  },
   render: () => (
     <Frame>
       <VariantCalmTable options={options} values={values} />
@@ -68,6 +76,14 @@ export const V1CalmTable: Story = {
 
 export const V2Cards: Story = {
   name: '2 · Cards',
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders the "Cards" compact-form variant over the shared basic schema — each field group is a card so the presentation reads as chunked panels.',
+      },
+    },
+  },
   render: () => (
     <Frame>
       <VariantCards options={options} values={values} />
@@ -77,6 +93,14 @@ export const V2Cards: Story = {
 
 export const V3Focus: Story = {
   name: '3 · Focus',
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders the "Focus" compact-form variant over the richer focus-demo schema (named groups, required-group choices) so the variant is compared under full engine parity.',
+      },
+    },
+  },
   render: () => (
     <Frame>
       <VariantFocus options={focusOptions} values={focusValues} config={focusConfig} />
@@ -86,6 +110,14 @@ export const V3Focus: Story = {
 
 export const V4Minimal: Story = {
   name: '4 · Minimal',
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders the "Minimal" compact-form variant over the shared basic schema — the sparest of the four candidates, only labels and values.',
+      },
+    },
+  },
   render: () => (
     <Frame>
       <VariantMinimal options={options} values={values} />
@@ -96,6 +128,14 @@ export const V4Minimal: Story = {
 /** All four stacked, labelled — for a quick scroll-through comparison. */
 export const CompareAll: Story = {
   name: '★ Compare all',
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders all four compact-form variants stacked in a single scroll — the Calm Table, Cards, Focus and Minimal layouts sit under labelled panels so they can be compared side by side.',
+      },
+    },
+  },
   render: () => {
     const items: [string, React.ReactNode][] = [
       ['1 · Calm Table', <VariantCalmTable key='v1' options={options} values={values} />],

--- a/src/components/form/expressions/ExpressionField.stories.tsx
+++ b/src/components/form/expressions/ExpressionField.stories.tsx
@@ -50,6 +50,14 @@ export const Default: Story = {
   args: {
     value: SAMPLE,
   },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders ExpressionField holding a "$local:name == John" expression — the Visual builder shows the Logical Equals operator with its two operands and the Visual/Text mode toggle.',
+      },
+    },
+  },
   async play({ canvasElement }) {
     const canvas = within(canvasElement);
 
@@ -72,6 +80,14 @@ export const Empty: Story = {
   args: {
     value: { is_expression: true, value: { args: [] } },
     defaultMode: 'text',
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders ExpressionField in Text mode with an empty expression AST — the "Parsed" preview shows the "(empty)" placeholder for an empty expression.',
+      },
+    },
   },
   async beforeEach() {
     const stop = startDpqlMockLsp();
@@ -102,6 +118,14 @@ export const Empty: Story = {
  * builder, and the Visual/Text toggle is present.
  */
 export const ViaFormEngine: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders a FormEngine schema with a bool option that carries supports_expressions and a stored expression value — the engine routes through TemplateField and mounts the ExpressionField shell with the Visual builder and the Visual/Text toggle.',
+      },
+    },
+  },
   render: () => {
     const [value, setValue] = useState<any>({
       condition: { type: 'bool', value: SAMPLE.value, is_expression: true },
@@ -150,6 +174,14 @@ export const ViaFormEngine: Story = {
  * renders the same AST.
  */
 export const ViaFormEngineTextMode: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders the FormEngine expression field, then switches to Text mode — the DPQL editor seeds from the stored AST via the mock LSP\'s dpql/serialize call and the "Parsed" preview mirrors it.',
+      },
+    },
+  },
   render: ViaFormEngine.render,
   async beforeEach() {
     const stop = startDpqlMockLsp();
@@ -200,6 +232,14 @@ export const ViaFormEngineTextMode: Story = {
  * the seeded direction is covered by `ViaFormEngineTextMode` above.)
  */
 export const ViaFormEngineTextTyping: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders the FormEngine expression field with an empty AST in Text mode. Typing DPQL text triggers the mock LSP\'s dpql/parse and the parsed expression lands in the form value with is_expression set.',
+      },
+    },
+  },
   render: (args) => {
     const [value, setValue] = useState<any>({
       condition: { type: 'bool', value: { args: [] }, is_expression: true },
@@ -277,6 +317,14 @@ export const TextMode: Story = {
     value: { is_expression: true, value: { args: [] } },
     defaultMode: 'text',
   },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders ExpressionField in Text (DPQL) mode over a mock-socket LSP. Typing DPQL text triggers dpql/parse and the "Parsed" preview reflects the resulting AST.',
+      },
+    },
+  },
   async beforeEach() {
     const stop = startDpqlMockLsp();
     return () => stop();
@@ -309,6 +357,14 @@ export const TextMode: Story = {
  * Driven live for the toggle interaction.
  */
 export const ToggleInFormEngine: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders a FormEngine schema with a plain bool option (supports_expressions, no value). Clicking More then "Use Expression" flips the field to expression mode and the ExpressionField shell with the Visual builder mounts in place of the checkbox.',
+      },
+    },
+  },
   render: () => {
     const [value, setValue] = useState<any>({});
     return (
@@ -380,7 +436,15 @@ export const Live: Story = {
   // (network/auth), still snapshotted by Chromatic. Mirrors the DpqlEditor
   // live stories.
   tags: ['!test'],
-  parameters: { live: true },
+  parameters: {
+    live: true,
+    docs: {
+      description: {
+        story:
+          'Renders ExpressionField against a live Qorus instance — the picker fetches the real ~121-function catalogue rather than the mock, and the seeded "contains" expression exercises the schema-driven operators and operands.',
+      },
+    },
+  },
   args: {
     type: 'bool',
     value: {
@@ -423,7 +487,15 @@ export const Live: Story = {
  */
 export const LiveExplain: Story = {
   tags: ['!test'],
-  parameters: { live: true },
+  parameters: {
+    live: true,
+    docs: {
+      description: {
+        story:
+          'Renders ExpressionField in Text mode against a live Qorus instance — the "Parsed" preview uses the server-rendered form via dpql/renderExpression rather than the client-side approximation.',
+      },
+    },
+  },
   args: {
     value: {
       is_expression: true,

--- a/src/components/form/expressions/builder/ExpressionBuilder.stories.tsx
+++ b/src/components/form/expressions/builder/ExpressionBuilder.stories.tsx
@@ -113,6 +113,14 @@ export const Default: Story = {
   args: {
     returnType: ['string', 'int'],
   },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders the ExpressionBuilder with no value and a string-or-int return type — a single empty expression card is shown so the operator can pick an operation.',
+      },
+    },
+  },
   play: async () => {
     await waitFor(() => expect(expressionCount()).toBe(1), { timeout: 10000 });
   },
@@ -121,6 +129,14 @@ export const Default: Story = {
 export const DefaultBoolean: Story = {
   args: {
     returnType: ['boolean'],
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders the ExpressionBuilder with no value and a boolean return type — a single empty expression card is shown so the operator can pick a boolean-returning operation.',
+      },
+    },
   },
   play: async () => {
     await waitFor(() => expect(expressionCount()).toBe(1), { timeout: 10000 });
@@ -139,6 +155,14 @@ export const WithSimpleValue: Story = {
           { type: 'string', value: 'es' },
           { type: 'bool', value: true },
         ],
+      },
+    },
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders the ExpressionBuilder holding a single "contains" expression with three arguments — the card shows the operation and each operand slot.',
       },
     },
   },
@@ -234,6 +258,14 @@ export const WithComplexValue: Story = {
       },
     },
   },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders the ExpressionBuilder holding a nested &&/|| expression with six leaf expressions — the builder shows the full expression tree with the AND/OR group cards and their operand cards.',
+      },
+    },
+  },
   play: async () => {
     await waitFor(() => expect(expressionCount()).toBe(6), { timeout: 10000 });
   },
@@ -241,6 +273,15 @@ export const WithComplexValue: Story = {
 
 export const ShowsExplanation: Story = {
   ...WithComplexValue,
+  parameters: {
+    ...WithComplexValue.parameters,
+    docs: {
+      description: {
+        story:
+          'Renders the nested expression tree and clicks Explain — the plain-language explanation of the whole expression is shown alongside the builder.',
+      },
+    },
+  },
   play: async (args) => {
     await WithComplexValue.play!(args);
     await clickButtonByLabel('Explain');
@@ -260,6 +301,15 @@ export const Readonly: Story = {
     ...WithComplexValue.args,
     readOnly: true,
   },
+  parameters: {
+    ...WithComplexValue.parameters,
+    docs: {
+      description: {
+        story:
+          'Renders the nested expression tree with readOnly enabled — the tree is visible but the AND/OR add-group controls are hidden so the operator cannot mutate it.',
+      },
+    },
+  },
   play: async (args) => {
     await WithComplexValue.play!(args);
     expect(document.querySelector('.expression-and')).toBeNull();
@@ -268,6 +318,15 @@ export const Readonly: Story = {
 
 export const FocusedEditing: Story = {
   ...WithComplexValue,
+  parameters: {
+    ...WithComplexValue.parameters,
+    docs: {
+      description: {
+        story:
+          'Renders the nested expression tree, hovers a card and clicks its fullscreen action — the focused-editing modal opens over that subtree.',
+      },
+    },
+  },
   play: async (args) => {
     await WithComplexValue.play!(args);
     await userEvent.hover(document.querySelectorAll('.expression')[0]);
@@ -287,6 +346,14 @@ export const FocusedEditing: Story = {
 export const WithArgWithAllowedValues: Story = {
   args: {
     returnType: ['bool'],
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders an empty ExpressionBuilder and selects "Matches Regular Expression" — the third operand ("Regex Options") carries element_allowed_values and renders the "Select one or more" picker.',
+      },
+    },
   },
   play: async (args) => {
     await Default.play!(args);
@@ -311,6 +378,14 @@ export const WithIntType: Story = {
       },
     },
   },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders the ExpressionBuilder with an int-typed >= expression comparing $local:input to 20 — the operands render as Number fields inside the expression card.',
+      },
+    },
+  },
   play: async () => {
     await waitFor(() => expect(expressionCount()).toBe(1), { timeout: 10000 });
   },
@@ -326,6 +401,15 @@ export const WithIntType: Story = {
  */
 export const ArgsChangeWhenOperatorChanges: Story = {
   ...WithSimpleValue,
+  parameters: {
+    ...WithSimpleValue.parameters,
+    docs: {
+      description: {
+        story:
+          'Renders the seeded "String Contains" expression, then switches the operation to "Matches Regular Expression" — the string operands carry over and the new "Regex Options" allowed-values operand appears.',
+      },
+    },
+  },
   play: async () => {
     // Both string operands of the seeded `contains` render as textareas.
     await waitFor(
@@ -344,6 +428,14 @@ export const NewGroupsCanBeCreated: Story = {
     ...WithSimpleValue.args,
     returnType: ['bool'],
   },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders the seeded "String Contains" expression, then clicks the AND and OR add-group actions — the tree grows from 1 to 3 expression cards as new grouping levels are added.',
+      },
+    },
+  },
   play: async () => {
     await waitFor(() => expect(expressionCount()).toBe(1), { timeout: 10000 });
 
@@ -357,6 +449,15 @@ export const NewGroupsCanBeCreated: Story = {
 
 export const GroupsCanBeDeleted: Story = {
   ...WithComplexValue,
+  parameters: {
+    ...WithComplexValue.parameters,
+    docs: {
+      description: {
+        story:
+          'Renders the nested expression tree (6 cards) and removes one group — the tree shrinks to 5 cards after the delete.',
+      },
+    },
+  },
   play: async () => {
     await waitFor(() => expect(expressionCount()).toBe(6), { timeout: 10000 });
 
@@ -377,6 +478,14 @@ export const GroupsCanBeDeleted: Story = {
  * inline `AiAssistanceAction({ context: selectedExpression })` captured.
  */
 export const WithInjectedExtraActions: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders the nested expression tree with an extraActions factory that injects an AI-assist button per card. Hovering an expression reveals the injected action alongside the built-in ones.',
+      },
+    },
+  },
   args: {
     ...WithComplexValue.args,
     extraActions: ({ selectedExpression }) => [
@@ -428,6 +537,14 @@ export const ExpressionWithIntReturnType: Story = {
       is_expression: true,
     },
   },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders the ExpressionBuilder with a "+" (Addition) varargs expression holding four int operands — the three "rest" args each expose a remove-argument button.',
+      },
+    },
+  },
   play: async () => {
     await waitFor(() => expect(expressionCount()).toBe(1), { timeout: 10000 });
     // Three "rest" args → three remove-argument buttons.
@@ -438,6 +555,15 @@ export const ExpressionWithIntReturnType: Story = {
 /** Remove one variable argument — the remove-arg count drops from 3 to 2. */
 export const VariableArgumentsCanBeRemoved: Story = {
   ...ExpressionWithIntReturnType,
+  parameters: {
+    ...ExpressionWithIntReturnType.parameters,
+    docs: {
+      description: {
+        story:
+          'Renders the "+" varargs expression and clicks one remove-argument button — one operand disappears and the remove-arg count drops from 3 to 2.',
+      },
+    },
+  },
   play: async (args) => {
     await ExpressionWithIntReturnType.play!(args);
 
@@ -450,6 +576,15 @@ export const VariableArgumentsCanBeRemoved: Story = {
 /** Remove one then add one back — the count returns to 3. */
 export const VariableArgumentsCanBeAdded: Story = {
   ...ExpressionWithIntReturnType,
+  parameters: {
+    ...ExpressionWithIntReturnType.parameters,
+    docs: {
+      description: {
+        story:
+          'Renders the "+" varargs expression, removes one operand and then adds one back — the remove-arg count moves 3 → 2 → 3.',
+      },
+    },
+  },
   play: async (args) => {
     await ExpressionWithIntReturnType.play!(args);
 
@@ -487,6 +622,14 @@ export const ExpressionCanBeWrapped: Story = {
     returnType: ['string', 'int'],
     value: seededConvert,
   },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders a seeded "Convert to Boolean" expression, hovers the card and picks "Join List Elements" from the Wrap picker — the outer op mounts and the original expression becomes its first operand.',
+      },
+    },
+  },
   play: async () => {
     // Seeded base op + its operand render.
     await waitFor(() => expect(expressionCount()).toBe(1), { timeout: 10000 });
@@ -506,6 +649,15 @@ export const ExpressionCanBeWrapped: Story = {
 /** Wrap, then unwrap — back to a single expression card. */
 export const ExpressionCanBeUnwrapped: Story = {
   ...ExpressionCanBeWrapped,
+  parameters: {
+    ...ExpressionCanBeWrapped.parameters,
+    docs: {
+      description: {
+        story:
+          'Renders the wrapped expression from ExpressionCanBeWrapped, then hovers and unwraps the outer op — the inner "Convert to Boolean" survives and the outer wrapper is removed.',
+      },
+    },
+  },
   play: async (args) => {
     await ExpressionCanBeWrapped.play!(args);
 
@@ -579,6 +731,14 @@ const SeededMismatchBase: Story = {
  * exact, so the builder flags it and the confirmation modal mounts.
  */
 export const FunctionArgsArePassedToNewFunctionAndNeedConfirmation: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders a valued "Format Date" expression and switches the operation to "Matches Regular Expression" — the carried date arg is accepted-but-not-exact for the new richtext operand and the mismatched-arguments confirmation modal mounts.',
+      },
+    },
+  },
   args: {
     returnType: 'string',
     value: {
@@ -616,6 +776,15 @@ export const FunctionArgsArePassedToNewFunctionAndNeedConfirmation: Story = {
 /** "Confirm selection" keeps the (still-selected) mismatched arg, transformed. */
 export const AcceptIncompatibleFunctionArgsSelection: Story = {
   ...SeededMismatchBase,
+  parameters: {
+    ...SeededMismatchBase.parameters,
+    docs: {
+      description: {
+        story:
+          'Renders the seeded mismatch-flagged expression, then clicks "Confirm selection" on the mismatched-arguments modal — the (still-selected) argument is kept and transformed to the new expected type.',
+      },
+    },
+  },
   play: async (args) => {
     await SeededMismatchBase.play!(args);
 
@@ -636,6 +805,15 @@ export const AcceptIncompatibleFunctionArgsSelection: Story = {
 /** "Accept all" — every mismatched arg is transformed and kept. */
 export const AcceptAllIncompatibleFunctionArgs: Story = {
   ...SeededMismatchBase,
+  parameters: {
+    ...SeededMismatchBase.parameters,
+    docs: {
+      description: {
+        story:
+          'Renders the seeded mismatch-flagged expression, then clicks "Accept all" on the mismatched-arguments modal — every flagged argument is transformed and kept.',
+      },
+    },
+  },
   play: async (args) => {
     await SeededMismatchBase.play!(args);
 
@@ -655,6 +833,15 @@ export const AcceptAllIncompatibleFunctionArgs: Story = {
 /** "Discard all" — every mismatched arg is cleared. */
 export const DiscardAllIncompatibleFunctionArgs: Story = {
   ...SeededMismatchBase,
+  parameters: {
+    ...SeededMismatchBase.parameters,
+    docs: {
+      description: {
+        story:
+          'Renders the seeded mismatch-flagged expression, then clicks "Discard all" on the mismatched-arguments modal — every flagged argument is cleared.',
+      },
+    },
+  },
   play: async (args) => {
     await SeededMismatchBase.play!(args);
 

--- a/src/components/form/fields/Field.stories.tsx
+++ b/src/components/form/fields/Field.stories.tsx
@@ -40,6 +40,14 @@ export const SoftInteger: Story = {
     type: 'softint',
     value: 5,
   },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders FormField for a softint value — the dispatcher resolves the soft type to int and mounts the numeric input.',
+      },
+    },
+  },
   async play({ canvasElement }) {
     // NumberFormField renders an input (a `softint` resolves to `int`).
     await expect(canvasElement.querySelector('input')).toBeInTheDocument();
@@ -52,6 +60,14 @@ export const Binary: Story = {
     type: 'binary',
     value: 'deadbeef',
   },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders FormField for a binary value — the dispatcher mounts a textarea holding the encoded content.',
+      },
+    },
+  },
   async play({ canvasElement }) {
     await expect(canvasElement.querySelector('textarea')).toBeInTheDocument();
   },
@@ -62,6 +78,14 @@ export const ByteSize: Story = {
   args: {
     type: 'byte-size',
     value: '512MiB',
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders FormField for a byte-size value — the dispatcher mounts the amount input and the MiB unit selector, split from "512MiB".',
+      },
+    },
   },
   async play({ canvasElement }) {
     const canvas = within(canvasElement);
@@ -75,6 +99,14 @@ export const Url: Story = {
   args: {
     type: 'url',
     value: 'https://example.com',
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders FormField for a url value — the dispatcher mounts the https protocol selector and the example.com address input, split from "https://example.com".',
+      },
+    },
   },
   async play({ canvasElement }) {
     const canvas = within(canvasElement);
@@ -93,6 +125,14 @@ export const MultiSelect: Story = {
       { value: { value: 'blue', type: 'string' }, display_name: 'Blue' },
     ],
     value: ['red', 'blue'],
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders FormField for a multi-select value — the two picked values (Red and Blue) render as chips using their display_name labels.',
+      },
+    },
   },
   async play({ canvasElement }) {
     const canvas = within(canvasElement);

--- a/src/components/form/fields/array/ArrayAutoField.stories.tsx
+++ b/src/components/form/fields/array/ArrayAutoField.stories.tsx
@@ -83,6 +83,14 @@ export const CompactEmpty: Story = {
     type: 'string',
     value: [],
   },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders ArrayAutoField in compact string mode with no items — only the entry input and a disabled confirm button are visible.',
+      },
+    },
+  },
   async play({ canvasElement }) {
     const canvas = within(canvasElement);
 
@@ -101,6 +109,14 @@ export const CompactWithValues: Story = {
   args: {
     type: 'string',
     value: ['hello', 'world'],
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders ArrayAutoField in compact string mode with two existing items — the values are shown as tags above the entry input.',
+      },
+    },
   },
   async play({ canvasElement }) {
     const canvas = within(canvasElement);
@@ -121,6 +137,14 @@ export const CompactAddItem: Story = {
   args: {
     type: 'string',
     value: ['existing'],
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders ArrayAutoField in compact string mode with one existing item. Typing into the input and clicking confirm appends the new item and fires onChange with the full list.',
+      },
+    },
   },
   async play({ args }) {
     await waitFor(
@@ -156,6 +180,14 @@ export const CompactEditItem: Story = {
   args: {
     type: 'string',
     value: ['alpha', 'beta'],
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders ArrayAutoField in compact string mode with two items. Clicking a tag\'s edit action loads its value into the input; editing and confirming replaces the tag in place.',
+      },
+    },
   },
   async play({ args }) {
     await waitFor(
@@ -199,6 +231,14 @@ export const CompactRemoveItem: Story = {
     type: 'string',
     value: ['one', 'two', 'three'],
   },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders ArrayAutoField in compact string mode with three items. Clicking the middle tag\'s remove action drops it from the list and fires onChange with the remaining two.',
+      },
+    },
+  },
   async play({ args }) {
     await waitFor(
       () => expect(document.querySelectorAll('.array-auto-compact-tag').length).toBe(3),
@@ -230,6 +270,14 @@ export const CompactWithNumbers: Story = {
     value: [10, 20, 30],
     renderItem: numberRenderItem,
   },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders ArrayAutoField in compact int mode with three numeric items — the tags show 10, 20 and 30 and the entry input uses the Number field.',
+      },
+    },
+  },
   async play() {
     await waitFor(
       () => expect(document.querySelectorAll('.array-auto-compact-tag').length).toBe(3),
@@ -243,6 +291,14 @@ export const CompactDisabled: Story = {
     type: 'string',
     value: ['locked'],
     disabled: true,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders ArrayAutoField in compact string mode with one item but disabled — the tag is visible without edit/remove actions and no entry input is shown.',
+      },
+    },
   },
   async play() {
     await waitFor(
@@ -266,6 +322,14 @@ export const ComplexHashItems: Story = {
     type: 'hash',
     value: [{ key: 'value' }],
     display_name: 'Hash Items',
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders ArrayAutoField in hash mode with one hash item — the field switches to the panel-based layout rather than compact tags.',
+      },
+    },
   },
   async play() {
     // Should render panel-based UI, not compact tags

--- a/src/components/form/fields/auto/AutoFormField.stories.tsx
+++ b/src/components/form/fields/auto/AutoFormField.stories.tsx
@@ -57,6 +57,14 @@ const waitForText = async (text: string | RegExp) => {
 /** Auto type, no value — the picker is shown and the field area prompts for a type. */
 export const Empty: Story = {
   args: {},
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders AutoFormField with no value or defaultType — the type picker is shown and the field area prompts the operator to pick a data type.',
+      },
+    },
+  },
   async play({ canvasElement }) {
     const canvas = within(canvasElement);
     // The IDE auto resolves its type in a mount effect — assert asynchronously.
@@ -70,6 +78,14 @@ export const Empty: Story = {
 export const InferredInteger: Story = {
   args: {
     value: 42,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders AutoFormField with a pre-existing numeric value of 42 — the type is inferred as int and the numeric input is shown without prompting for a type.',
+      },
+    },
   },
   async play({ canvasElement }) {
     const canvas = within(canvasElement);
@@ -86,6 +102,14 @@ export const InferredText: Story = {
   args: {
     value: 'hello world',
   },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders AutoFormField with a pre-existing string value — the type is inferred as string and the text field is shown holding "hello world".',
+      },
+    },
+  },
   async play({ canvasElement }) {
     const canvas = within(canvasElement);
     await expect(await canvas.findByDisplayValue('hello world')).toBeInTheDocument();
@@ -96,6 +120,14 @@ export const InferredText: Story = {
 export const ConcreteString: Story = {
   args: {
     defaultType: 'string',
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders AutoFormField with a concrete defaultType of string — the text field is shown directly, no type picker. Typing "abc" fires onChange with the value and inferred type.',
+      },
+    },
   },
   async play({ canvasElement, args }) {
     const canvas = within(canvasElement);
@@ -120,6 +152,14 @@ export const Nullable: Story = {
     defaultType: 'string',
     value: 'some text',
     canBeNull: true,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders AutoFormField with canBeNull enabled. Clicking "Set as null" clears the value to null, hides the field editor and flips the toggle to "Unset null".',
+      },
+    },
   },
   async play({ canvasElement, args }) {
     const canvas = within(canvasElement);
@@ -147,6 +187,14 @@ export const AllowedTypesSubset: Story = {
       { name: 'string', display_name: 'Text' },
     ],
   },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders AutoFormField with allowedTypes restricted to Integer and Text — the picker badge shows 2 available types instead of the full 14.',
+      },
+    },
+  },
   async play() {
     // The picker badge reflects the restricted list — 2 instead of 14.
     await waitForText('Please select data type');
@@ -159,6 +207,14 @@ export const NoSoftTypes: Story = {
   args: {
     noSoft: true,
   },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders AutoFormField with noSoft enabled — the soft* type variants are hidden and the picker badge reads 9 instead of 14.',
+      },
+    },
+  },
   async play() {
     await waitForText('Please select data type');
     await waitForText('9');
@@ -170,6 +226,14 @@ export const NoSoftTypes: Story = {
  * `auto` renders the picker for free, via FormEngine → TemplateField → auto.
  */
 export const ViaFormEngine: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders a FormEngine schema whose single option is typed as auto — the engine flows through TemplateField and renders the AutoFormField picker without any extra wiring.',
+      },
+    },
+  },
   render: () => {
     const [val, setVal] = useState<any>({});
     return (
@@ -222,6 +286,14 @@ export const StringWithAllowedValues: Story = {
       },
     ],
   },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders AutoFormField for a string with two allowed values — the operator picks from the constrained list rather than typing freely.',
+      },
+    },
+  },
 };
 
 export const RichText: Story = {
@@ -230,6 +302,14 @@ export const RichText: Story = {
     value: 'something',
     allowTemplates: true,
     templates: buildTemplates(templates as any),
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders AutoFormField in richtext mode with templates enabled. Typing appends to the existing value inside the contenteditable editor.',
+      },
+    },
   },
   play: async ({ canvasElement }) => {
     await waitFor(() => canvasElement.querySelector('div[contenteditable]'), {
@@ -264,6 +344,14 @@ export const ConnectionWithAllowedValues: Story = {
       },
     ],
   },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders AutoFormField for a connection with two allowed values — clicking "Please select" opens the item picker modal titled "Select from items".',
+      },
+    },
+  },
   play: async () => {
     // connection is a no-compact type → the allowed values render as the
     // select with the item collection (the IDE asserts the same modal title).
@@ -277,6 +365,14 @@ export const Hash: Story = {
   args: {
     value: jsyaml.dump({ key: 'value' }),
   },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders AutoFormField with a YAML-serialized hash value — the type is inferred as hash and the object editor is shown holding the parsed data.',
+      },
+    },
+  },
 };
 
 export const File: Story = {
@@ -288,12 +384,28 @@ export const File: Story = {
       size: 1234,
     },
   },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders AutoFormField in file mode holding a text-file value — the file field shows the file name in place of the drop zone.',
+      },
+    },
+  },
 };
 
 export const AutoDoesNotChangeTypeBackToAuto: Story = {
   args: {
     defaultType: 'auto',
     value: 'test',
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders AutoFormField in auto mode with a string value — the inferred type ("string") is shown and the picker still exposes all 14 types so the operator can switch away from auto without the field snapping back.',
+      },
+    },
   },
   play: async () => {
     await waitForText('string');
@@ -317,6 +429,14 @@ export const ListWithAllowedValues: Story = {
       },
     ],
   },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders AutoFormField in list mode restricted to two allowed list values — the operator picks one of the pre-defined lists rather than composing their own.',
+      },
+    },
+  },
 };
 
 export const ListWithCreatableAllowedValues: Story = {
@@ -337,11 +457,27 @@ export const ListWithCreatableAllowedValues: Story = {
       },
     ],
   },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders AutoFormField in list mode with two allowed values but with allowed_values_creatable enabled — the operator can pick a canned list or compose a custom one.',
+      },
+    },
+  },
 };
 
 export const ListWithElementType: Story = {
   args: {
     defaultType: 'list',
     element_type: 'int',
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders AutoFormField in list mode with an int element type — new items are added as integers rather than requiring the operator to pick a per-item type.',
+      },
+    },
   },
 };

--- a/src/components/form/fields/binary/Binary.stories.tsx
+++ b/src/components/form/fields/binary/Binary.stories.tsx
@@ -38,6 +38,14 @@ export const WithValue: Story = {
   args: {
     value: 'cGFzc3dvcmQ=',
   },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders the Binary field pre-populated with a base64 payload — the textarea shows the encoded string.',
+      },
+    },
+  },
   async play({ canvasElement }) {
     const canvas = within(canvasElement);
     const textarea = canvas.getByLabelText('Binary');
@@ -48,6 +56,14 @@ export const WithValue: Story = {
 };
 
 export const TypingUpdatesValue: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders the empty Binary field. Typing a base64 string into the textarea updates the value and fires onChange after the debounce.',
+      },
+    },
+  },
   async play({ canvasElement, args }) {
     const canvas = within(canvasElement);
     const textarea = canvas.getByLabelText('Binary');
@@ -61,6 +77,14 @@ export const TypingUpdatesValue: Story = {
 };
 
 export const UploadEncodesFileAsBase64: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders the Binary field with its file drop zone. Uploading a file encodes it as base64 (data-URL prefix stripped) and fires onChange with the encoded string.',
+      },
+    },
+  },
   async play({ canvasElement, args }) {
     const file = new File(['hello'], 'test.bin', { type: 'application/octet-stream' });
     // the hidden file input rendered by the reused ReqraftFileFormField drop zone
@@ -80,6 +104,14 @@ export const Disabled: Story = {
   args: {
     value: 'cGFzc3dvcmQ=',
     disabled: true,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders the Binary field with a base64 value but disabled — the textarea is non-interactive.',
+      },
+    },
   },
   async play({ canvasElement }) {
     const canvas = within(canvasElement);

--- a/src/components/form/fields/boolean/Boolean.stories.tsx
+++ b/src/components/form/fields/boolean/Boolean.stories.tsx
@@ -34,6 +34,14 @@ export const Checked: Story = {
   args: {
     checked: true,
   },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders the Boolean field in the checked state. Clicking the toggle flips it to unchecked and fires onChange with false.',
+      },
+    },
+  },
   async play({ canvasElement, args }) {
     const canvas = within(canvasElement);
 
@@ -49,6 +57,14 @@ export const Unchecked: Story = {
   args: {
     checked: false,
   },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders the Boolean field in the unchecked state. Clicking the toggle flips it to checked and fires onChange with true.',
+      },
+    },
+  },
   async play({ canvasElement, args }) {
     const canvas = within(canvasElement);
 
@@ -63,5 +79,13 @@ export const Disabled: Story = {
   args: {
     checked: true,
     disabled: true,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders the Boolean field checked and disabled — the toggle is visible but non-interactive.',
+      },
+    },
   },
 };

--- a/src/components/form/fields/byte-size/ByteSize.stories.tsx
+++ b/src/components/form/fields/byte-size/ByteSize.stories.tsx
@@ -30,6 +30,14 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders the ByteSize field with no value. Typing a number into the amount input fires onChange with the composed byte-size expression.',
+      },
+    },
+  },
   play: async ({ canvasElement, args }) => {
     const canvas = within(canvasElement);
     const input = canvas.getByLabelText('Byte size amount');
@@ -43,6 +51,14 @@ export const WithValue: Story = {
   args: {
     value: '512MiB',
   },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders the ByteSize field pre-populated with "512MiB" — the amount and unit are split across the number input and the MiB unit selector.',
+      },
+    },
+  },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     await expect(await canvas.findByDisplayValue('512')).toBeInTheDocument();
@@ -54,6 +70,14 @@ export const ReadOnly: Story = {
   args: {
     value: '512MiB',
     readOnly: true,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders the ByteSize field with "512MiB" in read-only mode — the amount input is marked readonly and rejects further edits.',
+      },
+    },
   },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);

--- a/src/components/form/fields/color/Color.stories.tsx
+++ b/src/components/form/fields/color/Color.stories.tsx
@@ -34,6 +34,14 @@ export const WithValue: Story = {
   args: {
     value: { r: 100, g: 149, b: 237, a: 1 },
   },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders the Color field with a cornflower-blue RGBA value pre-selected in the sketch picker.',
+      },
+    },
+  },
   async play({ canvasElement }) {
     const picker = canvasElement.querySelector('.sketch-picker');
     const colorPanel = canvasElement.querySelector('.saturation-white');
@@ -47,12 +55,26 @@ export const Red: Story = {
   args: {
     value: { r: 220, g: 53, b: 69, a: 1 },
   },
+  parameters: {
+    docs: {
+      description: {
+        story: 'Renders the Color field with a red RGBA value pre-selected in the sketch picker.',
+      },
+    },
+  },
   async play({ canvasElement }) {
     await expect(canvasElement.querySelector('.sketch-picker')).toBeInTheDocument();
   },
 };
 
 export const Empty: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story: 'Renders the Color field with no value — the sketch picker mounts empty.',
+      },
+    },
+  },
   async play({ canvasElement }) {
     await expect(canvasElement.querySelector('.sketch-picker')).toBeInTheDocument();
   },
@@ -62,6 +84,14 @@ export const Disabled: Story = {
   args: {
     value: { r: 100, g: 149, b: 237, a: 1 },
     disabled: true,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders the Color field with a value but disabled — the sketch picker is visible but non-interactive.',
+      },
+    },
   },
   async play({ canvasElement }) {
     await expect(canvasElement.querySelector('.sketch-picker')).toBeInTheDocument();

--- a/src/components/form/fields/cron/Cron.stories.tsx
+++ b/src/components/form/fields/cron/Cron.stories.tsx
@@ -39,6 +39,14 @@ export const Default: Story = {
       'aria-label': label,
     })),
   },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders the Cron field with a "1 1 1 1 1" schedule split across the Minute / Hour / Day / Month / Weekday inputs. Typing into a segment fires onChange with the recomposed expression; the clear button resets the value.',
+      },
+    },
+  },
 
   async play({ args, canvasElement }) {
     const canvas = within(canvasElement);

--- a/src/components/form/fields/date/Date.stories.tsx
+++ b/src/components/form/fields/date/Date.stories.tsx
@@ -30,6 +30,13 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Empty: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story: 'Renders the Date field with no value — the input mounts empty.',
+      },
+    },
+  },
   async play({ canvasElement }) {
     const input = canvasElement.querySelector('input');
     await expect(input).toBeInTheDocument();
@@ -39,6 +46,14 @@ export const Empty: Story = {
 export const WithValue: Story = {
   args: {
     value: '2025-01-15',
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders the Date field pre-populated with 2025-01-15 — the input shows the initial value without firing onChange.',
+      },
+    },
   },
   async play({ canvasElement, args }) {
     const input = canvasElement.querySelector('input');
@@ -51,5 +66,12 @@ export const Disabled: Story = {
   args: {
     value: '2025-06-01',
     disabled: true,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: 'Renders the Date field with a value but disabled — the input is non-interactive.',
+      },
+    },
   },
 };

--- a/src/components/form/fields/file/File.stories.tsx
+++ b/src/components/form/fields/file/File.stories.tsx
@@ -30,6 +30,14 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Empty: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders the File field with no value — the "Click or drop files here to upload" drop zone is visible.',
+      },
+    },
+  },
   async play({ canvasElement }) {
     const canvas = within(canvasElement);
     await expect(canvas.getByText('Click or drop files here to upload')).toBeInTheDocument();
@@ -44,6 +52,14 @@ export const WithValue: Story = {
       size: 28736,
     },
   },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders the File field pre-populated with a PDF value — the file name is displayed in place of the drop zone.',
+      },
+    },
+  },
   async play({ canvasElement }) {
     const canvas = within(canvasElement);
     await expect(canvas.getByText('report.pdf')).toBeInTheDocument();
@@ -56,6 +72,14 @@ export const WithImageValue: Story = {
       name: 'photo.png',
       content: 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==',
       size: 1024,
+    },
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders the File field pre-populated with a PNG image value — the file name and an inline preview thumbnail are shown.',
+      },
     },
   },
   async play({ canvasElement }) {
@@ -75,6 +99,14 @@ export const WithAcceptedExtensions: Story = {
       },
     },
   },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders the File field with an accept option limiting uploads to PNG, JPEG and PDF — the allowed extensions are listed below the drop zone.',
+      },
+    },
+  },
   async play({ canvasElement }) {
     const canvas = within(canvasElement);
     await expect(canvas.getByText('Click or drop files here to upload')).toBeInTheDocument();
@@ -85,6 +117,14 @@ export const WithAcceptedExtensions: Story = {
 export const Multiple: Story = {
   args: {
     multiple: true,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders the File field with multiple-selection enabled — the underlying input carries the multiple attribute and the drop zone stays visible after files are added.',
+      },
+    },
   },
   async play({ canvasElement }) {
     const canvas = within(canvasElement);
@@ -103,6 +143,14 @@ export const WithBuildTab: Story = {
     argSchema: {
       filename: { type: 'string', ui_type: 'string', display_name: 'Filename', required: true },
       content: { type: 'string', ui_type: 'string', display_name: 'Content', required: true },
+    },
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders the File field with an argSchema — a "Build a File" tab appears alongside the "Upload a File" drop zone so the user can synthesize a file from schema fields.',
+      },
     },
   },
   async play({ canvasElement }) {

--- a/src/components/form/fields/long-string/LongString.stories.tsx
+++ b/src/components/form/fields/long-string/LongString.stories.tsx
@@ -39,6 +39,14 @@ export const WithValue: Story = {
   args: {
     value: 'Hello world',
   },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders the LongString field pre-populated with "Hello world". Clicking clear empties the textarea and fires onChange; typing new content updates the value after the debounce.',
+      },
+    },
+  },
   async play({ canvasElement, args, step }) {
     const canvas = within(canvasElement);
     const textarea = canvas.getByLabelText('LongString');
@@ -66,6 +74,14 @@ export const WithValue: Story = {
 };
 
 export const Empty: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders the LongString field with no value. Typing into the empty textarea updates the value and fires onChange after the debounce.',
+      },
+    },
+  },
   async play({ canvasElement, args }) {
     const canvas = within(canvasElement);
     const textarea = canvas.getByLabelText('LongString');
@@ -85,6 +101,14 @@ export const Disabled: Story = {
   args: {
     value: 'Cannot edit this',
     disabled: true,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders the LongString field with a value but disabled — the textarea shows the value and rejects further edits.',
+      },
+    },
   },
   async play({ canvasElement }) {
     const canvas = within(canvasElement);

--- a/src/components/form/fields/markdown/Markdown.stories.tsx
+++ b/src/components/form/fields/markdown/Markdown.stories.tsx
@@ -35,6 +35,14 @@ export const Default: Story = {
   args: {
     'aria-label': 'MarkdownEditor',
   },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders the Markdown field pre-populated with the sample markdown fixture — the editor and the live preview render side by side.',
+      },
+    },
+  },
   async play({ canvasElement, args }) {
     const canvas = within(canvasElement);
     const editor = canvas.getByLabelText('MarkdownEditor');

--- a/src/components/form/fields/number/Number.stories.tsx
+++ b/src/components/form/fields/number/Number.stories.tsx
@@ -38,6 +38,14 @@ export const Integer: Story = {
     value: 42,
     type: 'int',
   },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders the Number field in integer mode with 42 pre-populated. Typing a new integer updates the value and fires onChange after the debounce.',
+      },
+    },
+  },
   async play({ args, canvasElement }) {
     const canvas = within(canvasElement);
     const input = canvas.getByLabelText('Number');
@@ -58,6 +66,14 @@ export const Float: Story = {
     value: 3.14,
     type: 'float',
   },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders the Number field in float mode with 3.14 pre-populated — the input uses a 0.1 step and accepts decimals.',
+      },
+    },
+  },
   async play({ args, canvasElement }) {
     const canvas = within(canvasElement);
     const input = canvas.getByLabelText('Number');
@@ -76,6 +92,13 @@ export const Empty: Story = {
   args: {
     type: 'int',
   },
+  parameters: {
+    docs: {
+      description: {
+        story: 'Renders the Number field in integer mode with no value — the input mounts empty.',
+      },
+    },
+  },
   async play({ canvasElement }) {
     const canvas = within(canvasElement);
     const input = canvas.getByLabelText('Number');
@@ -90,6 +113,14 @@ export const Disabled: Story = {
     value: 99,
     type: 'int',
     disabled: true,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders the Number field with a value but disabled — the input shows the value and rejects further edits.',
+      },
+    },
   },
   async play({ canvasElement }) {
     const canvas = within(canvasElement);

--- a/src/components/form/fields/object/Object.stories.tsx
+++ b/src/components/form/fields/object/Object.stories.tsx
@@ -50,6 +50,14 @@ export const Object: Story = {
     dataType: 'json',
     resultDataType: 'json',
   },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders the Object field in JSON object mode with no value. Clicking "New Object" seeds an empty JSON object in the editor.',
+      },
+    },
+  },
   async play() {
     await testsWaitForText('New Object');
     await testsClickButton({ label: 'New Object' });
@@ -63,6 +71,14 @@ export const List: Story = {
     type: 'array',
     dataType: 'yaml',
     resultDataType: 'yaml',
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders the Object field in YAML list mode with no value. Clicking "New List" seeds an empty list in the editor.',
+      },
+    },
   },
   async play() {
     await testsWaitForText('New List');
@@ -78,6 +94,14 @@ export const Disabled: Story = {
     dataType: 'native',
     resultDataType: 'native',
     disabled: true,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders the Object field in native-array mode but disabled — the field is visible and non-interactive.',
+      },
+    },
   },
 };
 
@@ -96,6 +120,14 @@ export const Small: Story = {
       false,
     ],
   },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders the Object field in native-array mode at "small" size with mixed item types — object, string, number and boolean.',
+      },
+    },
+  },
 };
 
 export const DisabledWithValue: Story = {
@@ -113,6 +145,14 @@ export const DisabledWithValue: Story = {
     ],
     disabled: true,
   },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders the Object field in native-array mode with a populated value but disabled — the items are visible in read-only form.',
+      },
+    },
+  },
 };
 
 export const NativeOnly: Story = {
@@ -128,6 +168,14 @@ export const NativeOnly: Story = {
       12,
       false,
     ],
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders the Object field in native-array mode with mixed item types — the native editor shows the items without a YAML/JSON textarea alternative.',
+      },
+    },
   },
   async play() {
     await testsWaitForText('"value"');
@@ -148,6 +196,14 @@ export const ValueCanBeRemoved: Story = {
       false,
     ],
   },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders the Object field with a populated native array. Clicking Remove clears the value and the field falls back to the "New List" placeholder.',
+      },
+    },
+  },
   async play() {
     await testsWaitForText('"value"');
     await testsClickButton({ label: 'Remove' });
@@ -165,6 +221,14 @@ export const Json: Story = {
       num: 23,
     }),
     resultDataType: 'json',
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders the Object field with a JSON string value. Switching to Text mode, editing the JSON and clicking Save fires onChange with the new JSON serialization.',
+      },
+    },
   },
   async play({ args }) {
     await testsWaitForText('"value"');
@@ -213,6 +277,14 @@ export const Yaml: Story = {
     }),
     resultDataType: 'yaml',
   },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders the Object field with a YAML string value. Switching to Text mode, editing the YAML and clicking Save fires onChange with the new YAML serialization.',
+      },
+    },
+  },
   async play({ args }) {
     await testsWaitForText('"value"');
     await testsClickButton({ label: 'Text' });
@@ -247,6 +319,14 @@ export const YamlToJson: Story = {
     }),
     resultDataType: 'json',
   },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders the Object field with a YAML input value and JSON output — editing the YAML in Text mode and saving fires onChange with the equivalent JSON string.',
+      },
+    },
+  },
   async play({ args }) {
     await testsWaitForText('"value"');
     await testsClickButton({ label: 'Text' });
@@ -280,6 +360,14 @@ export const NativeToYaml: Story = {
       num: 23,
     },
     resultDataType: 'yaml',
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders the Object field with a native object value and YAML output — editing in Text mode and saving fires onChange with the YAML serialization.',
+      },
+    },
   },
   async play({ args }) {
     await testsWaitForText('"value"');

--- a/src/components/form/fields/radio-group/RadioGroup.stories.tsx
+++ b/src/components/form/fields/radio-group/RadioGroup.stories.tsx
@@ -42,6 +42,14 @@ export const Default: Story = {
       { label: 'Python', value: 'Python', 'aria-label': 'Python' },
     ],
   },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders the RadioGroup field with three language options and "Qore" pre-selected. Clicking a different option fires onChange with the new value.',
+      },
+    },
+  },
   async play({ canvasElement, args }) {
     const canvas = within(canvasElement);
     const java = canvas.getByLabelText('Java');
@@ -59,6 +67,14 @@ export const WithImages: Story = {
       { label: 'Python', value: 'Python', image: python },
     ],
   },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders the RadioGroup field with three language options — each option displays its language logo alongside the label.',
+      },
+    },
+  },
   async play({ canvasElement }) {
     await expect(canvasElement.querySelector(`img[src="${qore}"]`)).toBeInTheDocument();
     await expect(canvasElement.querySelector(`img[src="${java}"]`)).toBeInTheDocument();
@@ -68,4 +84,12 @@ export const WithImages: Story = {
 
 export const Disabled: Story = {
   args: { ...Default.args, disabled: true },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders the RadioGroup field with three language options but disabled — the group is visible and non-interactive.',
+      },
+    },
+  },
 };

--- a/src/components/form/fields/rich-text/RichText.stories.tsx
+++ b/src/components/form/fields/rich-text/RichText.stories.tsx
@@ -33,6 +33,14 @@ export const WithValue: Story = {
   args: {
     value: 'Hello world',
   },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders the RichText field pre-populated with the plain-string value "Hello world" — the editor mounts with the text rendered as a paragraph.',
+      },
+    },
+  },
   async play({ canvasElement }) {
     const canvas = within(canvasElement);
     // Only assert on render — typing assertions would need waitFor due to debounce
@@ -42,6 +50,13 @@ export const WithValue: Story = {
 };
 
 export const Empty: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story: 'Renders the RichText field with no value — the editor mounts empty.',
+      },
+    },
+  },
   async play({ canvasElement }) {
     const canvas = within(canvasElement);
     await expect(canvas.getByRole('textbox')).toBeInTheDocument();
@@ -51,6 +66,14 @@ export const Empty: Story = {
 export const WithSlateValue: Story = {
   args: {
     value: [{ type: 'paragraph', children: [{ text: 'Rich text with Slate format' }] }],
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders the RichText field pre-populated with a Slate document rather than a plain string — the editor mounts with the paragraph node rendered as text.',
+      },
+    },
   },
   async play({ canvasElement }) {
     const canvas = within(canvasElement);

--- a/src/components/form/fields/schema-definition/SchemaDefinitionField.stories.tsx
+++ b/src/components/form/fields/schema-definition/SchemaDefinitionField.stories.tsx
@@ -40,6 +40,14 @@ type Story = StoryObj<typeof meta>;
 /** Empty definition — the catalogue drives the full tab set. */
 export const Empty: Story = {
   args: {},
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders the SchemaDefinition editor with no existing value — the Schema, Tables, Sequences and Migrations tabs mount straight from the catalogue.',
+      },
+    },
+  },
   async play({ canvasElement }) {
     const canvas = within(canvasElement);
     // Tabs come straight from the catalogue's `definition` sections.
@@ -59,12 +67,28 @@ export const Starter: Story = {
   args: {
     value: starterDefinition,
   },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders the SchemaDefinition editor seeded with the "example_schema" starter template — the Schema tab shows the single scaffolded table.',
+      },
+    },
+  },
 };
 
 /** A realistic populated schema — two tables, sequence, reference data, migrations. */
 export const Populated: Story = {
   args: {
     value: mockPopulatedDefinition,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders the SchemaDefinition editor with the populated fixture. Opening the Tables tab shows the customers and addresses tables.',
+      },
+    },
   },
   async play({ canvasElement }) {
     const canvas = within(canvasElement);
@@ -81,6 +105,14 @@ export const ReadOnly: Story = {
     value: mockPopulatedDefinition,
     readOnly: true,
   },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders the SchemaDefinition editor with readOnly enabled — every input becomes a typeset display row and no inputs, textareas or selects are rendered.',
+      },
+    },
+  },
   async play({ canvasElement }) {
     const canvas = within(canvasElement);
     await expect(await canvas.findByText('Schema')).toBeInTheDocument();
@@ -94,6 +126,14 @@ export const CatalogError: Story = {
   args: {
     catalogError: 'Schema options are unavailable on this server.',
   },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders the SchemaDefinition editor when the catalogue fetch fails — a "Could not load schema options" callout replaces the form.',
+      },
+    },
+  },
   async play({ canvasElement }) {
     const canvas = within(canvasElement);
     await expect(await canvas.findByText('Could not load schema options')).toBeInTheDocument();
@@ -106,6 +146,14 @@ export const CatalogError: Story = {
  * wired. `catalogOverride` rides in via `fieldProps`.
  */
 export const ViaFormField: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders the SchemaDefinition editor through the FormField dispatcher (type="schema-definition"). The catalogue is injected via fieldProps and the Schema and Tables tabs mount as usual.',
+      },
+    },
+  },
   render: () => {
     const [value, setValue] = useState<IDataSchemaDefinition | undefined>(mockPopulatedDefinition);
     return (
@@ -132,6 +180,14 @@ export const ViaFormField: Story = {
  * → FormField → SchemaDefinitionEditor).
  */
 export const ViaFormEngineUiType: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders a FormEngine schema whose "definition" option declares ui_type: schema-definition — FormEngine flows through TemplateField and FormField and mounts the schema editor with the injected catalogue.',
+      },
+    },
+  },
   render: () => {
     const [value, setValue] = useState<any>({
       definition: { type: 'hash', value: mockPopulatedDefinition },
@@ -177,6 +233,14 @@ export const Sandboxed: Story = {
     wrapperName: 'example_customer_addresses',
     value: mockPopulatedDefinition,
   },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders the SchemaDefinition editor for an untrusted (sandboxed) caller using the sandboxed catalogue — the Advanced tab and every trusted-only section are hidden.',
+      },
+    },
+  },
   async play({ canvasElement }) {
     const canvas = within(canvasElement);
     await expect(await canvas.findByText('Migrations')).toBeInTheDocument();
@@ -194,6 +258,14 @@ export const WithValidationBanner: Story = {
     catalogOverride: mockSchemaCatalog,
     wrapperName: 'renamed_schema',
     value: mockPopulatedDefinition,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders the SchemaDefinition editor when the wrapper interface name and the DataSchema name differ — the "name does not match" banner is shown, and clicking "Sync name" resolves the mismatch.',
+      },
+    },
   },
   async play({ canvasElement }) {
     const canvas = within(canvasElement);

--- a/src/components/form/fields/select/Select.stories.tsx
+++ b/src/components/form/fields/select/Select.stories.tsx
@@ -35,6 +35,14 @@ export const Items: Story = {
       { display_name: 'Item 2', value: 'item2' },
     ],
   },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders the Select field with two simple items and no value. Clicking the trigger opens the popover with the item list.',
+      },
+    },
+  },
   async play({ canvasElement }) {
     const canvas = within(canvasElement);
     await fireEvent.click(canvas.getByRole('button'));
@@ -45,6 +53,14 @@ export const Items: Story = {
 };
 
 export const ItemsWithDescription: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders the Select field with twenty items, each carrying a description, icon or image. Opening the picker mounts a modal collection with all twenty entries.',
+      },
+    },
+  },
   args: {
     items: [
       { display_name: 'Item 1', desc: 'This is item 1', value: 'item1', icon: 'MoneyEuroCircleFill', groups: ['Miscellaneous'] },
@@ -81,6 +97,14 @@ export const ItemsWithDescription: Story = {
 };
 
 export const ItemsWithDescriptionAndMessages: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders the Select field with two items that carry inline messages of different intents. The picker modal shows the messages beneath each item.',
+      },
+    },
+  },
   args: {
     items: [
       {
@@ -121,6 +145,14 @@ export const DisabledItemsWithIntent: Story = {
       { display_name: 'Disabled Item with Intent', intent: 'danger', disabled: true, value: 'item5' },
     ],
   },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders the Select field with a mix of enabled, disabled and intent-tagged items — the disabled entries are non-interactive while success/danger items carry their intent styling.',
+      },
+    },
+  },
   async play({ canvasElement }) {
     const canvas = within(canvasElement);
     await fireEvent.click(canvas.getByRole('button'));
@@ -137,6 +169,14 @@ export const DisabledItemsWithIntentAndDescriptions: Story = {
       { display_name: 'Item with intent', intent: 'success', short_desc: 'This is item 4', value: 'item4' },
       { display_name: 'Disabled Item with Intent', intent: 'danger', disabled: true, short_desc: 'This is item 5', value: 'item5' },
     ],
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders the Select field with five items mixing intents, descriptions and disabled states — the picker modal shows all five so their combined presentation can be reviewed.',
+      },
+    },
   },
   async play({ canvasElement }) {
     const canvas = within(canvasElement);
@@ -157,6 +197,14 @@ export const WithValue: Story = {
       { display_name: 'Item 2', value: 'item2' },
     ],
   },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders the Select field with two items and item2 pre-selected — the trigger shows the selected label and clicking it opens the popover.',
+      },
+    },
+  },
   async play({ canvasElement }) {
     const canvas = within(canvasElement);
     await expect(canvas.getByRole('button')).toBeInTheDocument();
@@ -173,6 +221,14 @@ export const WithValueAndErrors: Story = {
       { display_name: 'Item 2', desc: 'This is item 1', value: 'item2', image: 'https://avatars.githubusercontent.com/u/8861481?v=4' },
     ],
   },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders the Select field with a danger-intent item in the list, but the selected value points at the healthy item — the trigger stays clean while the picker highlights the danger item.',
+      },
+    },
+  },
 };
 
 export const WithValueAndErrorsSelected: Story = {
@@ -182,6 +238,14 @@ export const WithValueAndErrorsSelected: Story = {
       { display_name: 'Item 1', desc: 'This is item 1', intent: 'danger', value: 'item1' },
       { display_name: 'Item 2', desc: 'This is item 1', value: 'item2' },
     ],
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders the Select field with the danger-intent item pre-selected — the trigger carries the danger styling so the operator can see the selected item has an error.',
+      },
+    },
   },
 };
 
@@ -193,12 +257,28 @@ export const WithValueAndWarningsSelected: Story = {
       { display_name: 'Item 2', desc: 'This is item 1', value: 'item2' },
     ],
   },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders the Select field with a pre-selected item whose metadata declares needs_auth — the trigger surfaces the warning so the operator knows the item needs configuration.',
+      },
+    },
+  },
 };
 
 export const AutoSelect: Story = {
   args: {
     autoSelect: true,
     items: [{ display_name: 'Item 1', value: 'item1' }],
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders the Select field with autoSelect and a single item — the field auto-selects the only option and the trigger shows its label on mount.',
+      },
+    },
   },
   async play({ canvasElement }) {
     const canvas = within(canvasElement);
@@ -211,6 +291,14 @@ export const AutoSelectWithShortDescriptions: Story = {
     autoSelect: true,
     items: [{ display_name: 'Item 1', short_desc: 'Short item 1 description', value: 'item1' }],
   },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders the Select field with autoSelect and a single item that carries a short description — the field auto-selects and the trigger shows both the label and the short description.',
+      },
+    },
+  },
   async play({ canvasElement }) {
     const canvas = within(canvasElement);
     await waitFor(() => expect(canvas.getByText('Item 1')).toBeInTheDocument(), { timeout: 500 });
@@ -221,6 +309,14 @@ export const AutoSelectWithDescriptions: Story = {
   args: {
     autoSelect: true,
     items: [{ display_name: 'Item 1', desc: 'This is item 1', value: 'item1' }],
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders the Select field with autoSelect and a single item that carries a full description — the field auto-selects and the trigger shows the label with the description.',
+      },
+    },
   },
   async play({ canvasElement }) {
     const canvas = within(canvasElement);
@@ -239,6 +335,14 @@ export const ItemValuesAreObjectsAndCanBeSelected: Story = {
         value: { id: { type: 'string', value: 'item2' } },
       },
     ],
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders the Select field with items whose values are hashes rather than primitives. The unlabelled first item shows its JSON as the trigger label; picking the second item swaps the selection to its display_name.',
+      },
+    },
   },
   async play({ canvasElement }) {
     const canvas = within(canvasElement);

--- a/src/components/form/fields/string/String.stories.tsx
+++ b/src/components/form/fields/string/String.stories.tsx
@@ -38,6 +38,14 @@ export const Default: Story = {
   args: {
     value: 'Qore',
   },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders the String field pre-populated with "Qore". Clicking clear empties the input and fires onClearClick; typing new text updates the value and fires onChange.',
+      },
+    },
+  },
   play: async ({ canvasElement, args }) => {
     const canvas = within(canvasElement);
     const input = canvas.getByLabelText('Name');
@@ -59,6 +67,14 @@ export const Sensitive: Story = {
   args: {
     sensitive: true,
     value: 'password',
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders the String field in sensitive mode — the input renders as type="password" so the value is masked.',
+      },
+    },
   },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);

--- a/src/components/form/fields/template/TemplateField.stories.tsx
+++ b/src/components/form/fields/template/TemplateField.stories.tsx
@@ -209,6 +209,14 @@ export const StringComponent: StoryObj<typeof meta> = {
     value: 'Some string',
     type: 'string',
   },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders TemplateField wrapping a LongString component with a plain string value — the field shows the literal string in a textarea, no template selected.',
+      },
+    },
+  },
 };
 
 export const BooleanComponent: StoryObj<typeof meta> = {
@@ -217,6 +225,14 @@ export const BooleanComponent: StoryObj<typeof meta> = {
     type: 'boolean',
     allowTemplates: true,
     componentFromType: true,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders TemplateField for a boolean value with templates allowed — the boolean toggle is shown with the template toggle available on the side.',
+      },
+    },
   },
 };
 
@@ -227,6 +243,14 @@ export const NumberComponent: StoryObj<typeof meta> = {
     allowTemplates: true,
     componentFromType: true,
   },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders TemplateField for an int value of 25 with templates allowed — the numeric input is shown alongside the template toggle.',
+      },
+    },
+  },
 };
 
 export const AutoComponent: StoryObj<typeof meta> = {
@@ -234,6 +258,14 @@ export const AutoComponent: StoryObj<typeof meta> = {
     defaultType: 'auto',
     allowTemplates: true,
     component: auto,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders TemplateField wrapping the AutoFormField dispatcher — the operator can pick a type from the auto picker or switch to a template value.',
+      },
+    },
   },
 };
 
@@ -249,6 +281,14 @@ export const AllowedValuesWithTemplate: StoryObj<typeof meta> = {
     ],
     component: auto,
   },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders TemplateField restricted to a single allowed value ("Test") but with templates also allowed — the operator can pick the allowed value or switch to a template.',
+      },
+    },
+  },
 };
 
 export const TemplateValue: StoryObj<typeof meta> = {
@@ -256,6 +296,14 @@ export const TemplateValue: StoryObj<typeof meta> = {
     component: Number,
     type: 'int',
     value: '$local:id',
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders TemplateField for an int wrapped over the Number component with a template value ($local:id) — the template selector replaces the number input.',
+      },
+    },
   },
 };
 
@@ -271,6 +319,14 @@ export const ElementTypeInListShowsCorrectTemplates: StoryObj<typeof meta> = {
       { type: 'number', value: 3 },
     ],
   },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders TemplateField in list mode with three number items. Adding a new item and opening the templates popover shows the templates that resolve to the number element type.',
+      },
+    },
+  },
   play: async () => {
     await _testsClickButton({ label: 'Add new item for "Test"' });
     await _testsOpenTemplates();
@@ -280,6 +336,14 @@ export const ElementTypeInListShowsCorrectTemplates: StoryObj<typeof meta> = {
 
 export const ShowsTemplatesList: StoryObj<typeof meta> = {
   ...TemplateValue,
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders TemplateField with the $local:id template value, then opens the templates popover — the operator sees the available templates that resolve to an int.',
+      },
+    },
+  },
   play: async () => {
     await _testsOpenTemplates();
   },
@@ -287,6 +351,14 @@ export const ShowsTemplatesList: StoryObj<typeof meta> = {
 
 export const ShowsTemplatesListForString: StoryObj<typeof meta> = {
   ...StringComponent,
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders TemplateField over a LongString component with a plain string value, then opens the templates popover — the templates list is shown for a string target type.',
+      },
+    },
+  },
   play: async () => {
     await _testsOpenTemplates();
   },
@@ -294,6 +366,14 @@ export const ShowsTemplatesListForString: StoryObj<typeof meta> = {
 
 export const ShowsTemplatesListForBoolean: StoryObj<typeof meta> = {
   ...BooleanComponent,
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders TemplateField for a boolean value, switches to template mode and opens the templates popover — the templates list is shown for a boolean target type.',
+      },
+    },
+  },
   play: async () => {
     await _testsSetTemplate();
     await _testsOpenTemplates();
@@ -302,6 +382,14 @@ export const ShowsTemplatesListForBoolean: StoryObj<typeof meta> = {
 
 export const ShowsTemplatesListForNumber: StoryObj<typeof meta> = {
   ...NumberComponent,
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders TemplateField for an int value, then opens the templates popover — the templates list is shown for an int target type.',
+      },
+    },
+  },
   play: async () => {
     await _testsOpenTemplates();
   },
@@ -313,6 +401,14 @@ export const TemplateValueCanBeRemoved: StoryObj<typeof meta> = {
     type: 'boolean',
     allowTemplates: true,
     componentFromType: true,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders TemplateField holding a $config:boolean template value. Clicking the template-remove action clears the template and the underlying boolean checkbox is shown instead.',
+      },
+    },
   },
   play: async () => {
     await expect(document.querySelector('.template-selector')).toBeInTheDocument();
@@ -332,6 +428,14 @@ export const TemplateWithFunctions: StoryObj<typeof meta> = {
     fixed: true,
     fluid: false,
     expressions: storyExpressions as any,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders TemplateField with allowFunctions enabled — the template menu now exposes a "Use Expression" entry alongside the plain templates.',
+      },
+    },
   },
   play: async () => {
     await _testsOpenTemplateMenu();
@@ -357,6 +461,14 @@ export const TemplateWithFunctionValue: StoryObj<typeof meta> = {
     fixed: true,
     fluid: false,
     expressions: storyExpressions as any,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders TemplateField holding a substr function value with three arguments — the expression builder shows the function name and each argument slot.',
+      },
+    },
   },
 };
 
@@ -389,6 +501,14 @@ export const TemplateWithNestedFunctionValue: StoryObj<typeof meta> = {
     fluid: false,
     expressions: storyExpressions as any,
   },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders TemplateField holding a substr function whose second argument is itself a PLUS-INT expression — the expression builder shows the nested function inline within the outer call.',
+      },
+    },
+  },
 };
 
 export const TemplateCanBeSelected: StoryObj<typeof meta> = {
@@ -396,6 +516,14 @@ export const TemplateCanBeSelected: StoryObj<typeof meta> = {
     type: 'string',
     defaultType: 'string',
     defaultInternalType: 'string',
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders TemplateField for a string, opens the templates popover and clicks the Interface ID template — the field switches to the $local:id template value.',
+      },
+    },
   },
   play: async ({ canvasElement, ...rest }) => {
     const canvas = within(canvasElement);
@@ -410,6 +538,14 @@ export const TemplateCanBeSelected: StoryObj<typeof meta> = {
 };
 
 export const ValueIsResetWhenChangingToCustom: StoryObj<typeof meta> = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders TemplateField over a number type holding a $config:something template value. Clicking template-remove resets the value to undefined and fires onChange with the cleared value.',
+      },
+    },
+  },
   render: (args) => {
     const [value, setValue] = useState(args.value);
 
@@ -449,6 +585,14 @@ export const TemplatesWithMultipleLevels: StoryObj<typeof meta> = {
     type: 'string',
     templates: buildTemplates(multiLevelTemplates as any),
   },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders TemplateField for a string with a hierarchical template catalogue. Drilling into "Testing Hash" narrows the list to templates that resolve to a string (Testing Int Item is filtered out).',
+      },
+    },
+  },
   play: async () => {
     await _testsOpenTemplates();
     await _testsClickButton({ label: 'Testing Hash' });
@@ -458,6 +602,14 @@ export const TemplatesWithMultipleLevels: StoryObj<typeof meta> = {
 };
 
 export const TemplatesWithMultipleLevelsAndHashField: StoryObj<typeof meta> = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders TemplateField for a hash type with a hierarchical template catalogue — switching to template mode and opening the popover exposes the nested template groups.',
+      },
+    },
+  },
   render: (args) => {
     const [value, setValue] = useState(args.value);
 
@@ -486,6 +638,14 @@ export const TemplatesWithMultipleLevelsAndHashField: StoryObj<typeof meta> = {
 
 export const TemplateWithItemsCanBeSelected: StoryObj<typeof meta> = {
   ...TemplatesWithMultipleLevelsAndHashField,
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders TemplateField for a hash type with a hierarchical catalogue. Selecting an item from a nested group updates the template value to the picked entry (Testing Hash).',
+      },
+    },
+  },
   play: async (args) => {
     await TemplatesWithMultipleLevelsAndHashField.play(args);
     await _testsClickButton({ selector: '.reqore-menu-item-left-action' });

--- a/src/components/form/fields/url/Url.stories.tsx
+++ b/src/components/form/fields/url/Url.stories.tsx
@@ -30,6 +30,14 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders the Url field with no value. Typing into the address input recomposes the URL and fires onChange after the debounce; because no protocol is selected, the composed value keeps a bare "://" prefix.',
+      },
+    },
+  },
   play: async ({ canvasElement, args }) => {
     const canvas = within(canvasElement);
     const input = canvas.getByLabelText('URL address');
@@ -49,6 +57,14 @@ export const WithValue: Story = {
   args: {
     value: 'https://example.com',
   },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders the Url field pre-populated with "https://example.com" — the URL is split across the https protocol selector and the example.com address input.',
+      },
+    },
+  },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     await expect(await canvas.findByDisplayValue('example.com')).toBeInTheDocument();
@@ -59,6 +75,14 @@ export const WithValue: Story = {
 export const KeepsSeparatorInsideAddress: Story = {
   args: {
     value: 'https://proxy/forward?to=http://inner',
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders the Url field with a URL whose query-string embeds a second "://". The protocol split only consumes the leading separator; the inner "://" survives inside the address input.',
+      },
+    },
   },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);

--- a/src/components/log/Log.stories.tsx
+++ b/src/components/log/Log.stories.tsx
@@ -93,6 +93,14 @@ export default meta;
 export type Story = StoryObj<typeof meta>;
 
 export const Basic: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders ReqraftLog wired to a mock WebSocket that emits a stream of test log lines — the messages accumulate in the log panel as they arrive.',
+      },
+    },
+  },
   play: async () => {
     await testsWaitForText('This is a message with a link: https://www.qoretechnologies.com');
   },
@@ -102,6 +110,14 @@ export const Filterable: Story = {
   ...Basic,
   args: {
     filterable: true,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders ReqraftLog with the filter input enabled. Typing "error" narrows the visible list to the single ERROR message.',
+      },
+    },
   },
   play: async (args) => {
     await Basic.play(args);
@@ -115,6 +131,14 @@ export const WithTimestamps: Story = {
   args: {
     showTimestamps: true,
   },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders ReqraftLog with per-message timestamps enabled — each streamed line is prefixed with its arrival time.',
+      },
+    },
+  },
 };
 
 export const WithDefaultMessages: Story = {
@@ -126,12 +150,28 @@ export const WithDefaultMessages: Story = {
       { message: 'This is another default message', timestamp: '08:00:00.000' },
     ],
   },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders ReqraftLog seeded with two default messages — those lines appear before any messages arrive from the socket.',
+      },
+    },
+  },
 };
 
 export const WithCopyableMessages: Story = {
   ...Basic,
   args: {
     allowMessageCopy: true,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders ReqraftLog with allowMessageCopy — each message row exposes a copy action next to its content.',
+      },
+    },
   },
   play: async (args) => {
     await Basic.play(args);
@@ -144,6 +184,14 @@ export const WithDeletableMessages: Story = {
     allowMessageCopy: true,
     allowMessageDeletion: true,
   },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders ReqraftLog with copy and delete actions on every message. Clicking a message\'s delete action removes just that row from the log.',
+      },
+    },
+  },
   play: async (args) => {
     await Basic.play(args);
     await testsClickButton({ selector: '.reqraft-log-delete-message', nth: 4 });
@@ -155,6 +203,14 @@ export const Pause: Story = {
   args: {
     allowMessageDeletion: true,
   },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders ReqraftLog while messages stream in. Clicking the pause/resume action halts appending new messages until it is clicked again.',
+      },
+    },
+  },
   play: async () => {
     await testsWaitForText('This is another message');
     await testsClickButton({ selector: '.reqraft-log-pause-resume' });
@@ -165,6 +221,14 @@ export const Clear: Story = {
   ...Basic,
   args: {
     allowMessageDeletion: true,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders ReqraftLog with messages streamed in. Clicking the clear action empties the log and the "No messages" empty state is shown.',
+      },
+    },
   },
   play: async (args) => {
     await Basic.play(args);
@@ -192,6 +256,14 @@ export const FormattedMessages: Story = {
       return { message, ...rest };
     },
   },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders ReqraftLog with a messageFormatter that assigns intents by content — WARNING lines colour warning, ERROR lines danger and ALL-CAPS lines info.',
+      },
+    },
+  },
   play: async (args) => {
     await Basic.play(args);
   },
@@ -202,6 +274,14 @@ export const CanSendMessages: Story = {
   args: {
     canSendMessages: true,
     showTimestamps: true,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders ReqraftLog with canSendMessages — an input at the bottom lets the operator send a message back through the socket alongside the incoming stream.',
+      },
+    },
   },
   play: async (args) => {
     await Basic.play(args);
@@ -214,6 +294,14 @@ export const WithAutoScroll: Story = {
     autoScroll: true,
     style: { height: '200px' },
   },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders ReqraftLog with autoScroll in a fixed 200px viewport — the log stays pinned to the newest message as new lines arrive.',
+      },
+    },
+  },
   play: async (args) => {
     await Basic.play(args);
   },
@@ -224,6 +312,14 @@ export const WithAutoScrollAndManualScroll: Story = {
   args: {
     autoScroll: true,
     style: { height: '200px' },
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders ReqraftLog with autoScroll while the operator scrolls the panel manually — auto-scroll pauses so the operator can inspect older messages without being yanked back to the tail.',
+      },
+    },
   },
   play: async (args) => {
     await WithAutoScroll.play(args);

--- a/src/components/menu/Menu.stories.tsx
+++ b/src/components/menu/Menu.stories.tsx
@@ -27,6 +27,14 @@ export const Basic: Story = {
   args: {
     menu: typedMenu,
   },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders ReqraftMenu with the mock Qorus navigation — sections and items appear in the sidebar with no active path highlighted.',
+      },
+    },
+  },
   play: async () => {
     await testsWaitForText('Interfaces & More');
   },
@@ -35,6 +43,14 @@ export const ActivePath: Story = {
   args: {
     path: '/Interfaces/mapper',
     menu: typedMenu,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders ReqraftMenu with the /Interfaces/mapper path — the matching menu entry is highlighted as active.',
+      },
+    },
   },
   play: async () => {
     await testsWaitForText('Interfaces & More');
@@ -47,6 +63,14 @@ export const ActiveMenuItemIntent: Story = {
     menu: typedMenu,
     activeItemIntent: 'success',
   },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders ReqraftMenu with the /Interfaces/mapper path and a "success" activeItemIntent — the active entry uses the success intent for its highlight colour.',
+      },
+    },
+  },
   play: async () => {
     await testsWaitForText('Interfaces & More');
   },
@@ -56,6 +80,14 @@ export const WithDefaultQuery: Story = {
   args: {
     menu: typedMenu,
     defaultQuery: 'mapper',
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders ReqraftMenu with a defaultQuery of "mapper" — the search input is pre-filled and the visible items are narrowed to those matching the query.',
+      },
+    },
   },
   play: async () => {
     await testsWaitForText('Interfaces & More');
@@ -68,6 +100,14 @@ export const Filtered: Story = {
   args: {
     menu: typedMenu,
     onQueryChange: fn(),
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders ReqraftMenu with an onQueryChange handler. Typing "step" into the search filter narrows the visible items to just the matching entries.',
+      },
+    },
   },
   play: async () => {
     await testsWaitForText('Interfaces & More');
@@ -82,6 +122,12 @@ export const Filtered: Story = {
 export const WidthFromStorage: Story = {
   ...ActivePath,
   parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders ReqraftMenu backed by user storage that already holds a persisted width — the menu mounts at the stored width rather than the default.',
+      },
+    },
     mockData: [...storiesStorageMock],
   },
 };
@@ -92,6 +138,14 @@ export const WithCustomChildren: Story = {
     ...ActivePath.args,
     topChildren: <div style={{ padding: 10 }}>Top Custom Child</div>,
     bottomChildren: <div style={{ padding: 10 }}>Bottom Custom Child</div>,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders ReqraftMenu with topChildren and bottomChildren slots — custom nodes appear above and below the menu list.',
+      },
+    },
   },
   play: async () => {
     await testsWaitForText('Interfaces & More');

--- a/src/components/qonsoleSmartInput/QonsoleSmartInput.stories.tsx
+++ b/src/components/qonsoleSmartInput/QonsoleSmartInput.stories.tsx
@@ -398,6 +398,14 @@ export const BasicMock: Story = {
   args: {
     initialValue: '/list services ',
   },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders the QonsoleSmartInput against a mocked Qonsole LSP. Typing "-" after "/list services " opens the flag dropdown with --desc, --limit and --search; pressing Enter accepts the first item without producing a stray double dash.',
+      },
+    },
+  },
   async beforeEach() {
     const server = setupBasicQonsoleMockServer();
     return () => server.close();
@@ -509,6 +517,12 @@ export const LiveQonsoleWithContext: Story = {
   },
   parameters: {
     chromatic: { disable: true },
+    docs: {
+      description: {
+        story:
+          'Renders the QonsoleSmartInput against the real Qonsole LSP with a pre-bound "/use services" context — predictive text is scoped to the services resource via the qonsole/setContext call.',
+      },
+    },
   },
 };
 

--- a/src/components/smartEditor/SmartEditor.stories.tsx
+++ b/src/components/smartEditor/SmartEditor.stories.tsx
@@ -72,6 +72,14 @@ export const BasicMock: Story = {
     initialValue: '',
     triggerCharacters: new Set([' ', '.']),
   },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders the SmartEditor against a mocked LSP server. Typing the "." trigger character sends a completion request and the dropdown mounts with the apple and banana suggestions.',
+      },
+    },
+  },
   async beforeEach() {
     const lsp = createMockLspServer(MOCK_LSP_URL, {
       capabilities: {},
@@ -295,6 +303,14 @@ export const WithDiagnostics: Story = {
     languageId: 'demo',
     initialValue: 'list services in pricing',
   },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders the SmartEditor against a mocked LSP server that pushes diagnostics on didOpen — the text is decorated with wavy underlines and the stacked message panel below the editor lists both diagnostics.',
+      },
+    },
+  },
   async beforeEach() {
     const lsp = createMockLspServer(MOCK_LSP_URL, {
       capabilities: {},
@@ -342,6 +358,14 @@ export const ReadOnly: Story = {
     initialValue: 'frozen content',
     readOnly: true,
   },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders the SmartEditor in read-only mode over an initial value — the Slate editor mounts as contenteditable=false so the content shows but cannot be edited.',
+      },
+    },
+  },
   async beforeEach() {
     const lsp = createMockLspServer(MOCK_LSP_URL, { capabilities: {} });
     return () => lsp.close();
@@ -366,6 +390,14 @@ export const LoadingOverlay: Story = {
   args: {
     languageId: 'demo',
     initialValue: 'visible under the overlay',
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders the SmartEditor against a mock LSP that never finishes initialize — the "Connecting to language server" overlay stays over the editor for the whole session.',
+      },
+    },
   },
   async beforeEach() {
     const lsp = createMockLspServer(MOCK_LSP_URL, {

--- a/src/hooks/useFetch/useFetch.stories.tsx
+++ b/src/hooks/useFetch/useFetch.stories.tsx
@@ -35,6 +35,12 @@ export const Get: Story = {
     method: 'GET',
   },
   parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders a useFetch demo that issues a GET against /public/info on mount and displays the returned Qorus system info as a tree.',
+      },
+    },
     mockData: [
       {
         // An array of mock objects which will add in every story
@@ -66,6 +72,12 @@ export const Put: Story = {
     method: 'PUT',
   },
   parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders a useFetch demo that issues a PUT against /public/info on mount and displays the returned success status.',
+      },
+    },
     mockData: [
       {
         // An array of mock objects which will add in every story
@@ -88,6 +100,12 @@ export const Post: Story = {
     method: 'POST',
   },
   parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders a useFetch demo that issues a POST against /public/info on mount and displays the returned success status.',
+      },
+    },
     mockData: [
       {
         // An array of mock objects which will add in every story
@@ -110,6 +128,12 @@ export const Del: Story = {
     method: 'DELETE',
   },
   parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders a useFetch demo that issues a DELETE against /public/info on mount and displays the returned success status.',
+      },
+    },
     mockData: [
       {
         // An array of mock objects which will add in every story
@@ -132,6 +156,12 @@ export const Error409: Story = {
     method: 'POST',
   },
   parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders a useFetch demo that issues a POST returning a 409 error — the hook exposes errorData and the Qorus stack trace is rendered in place of the response.',
+      },
+    },
     mockData: [
       {
         // An array of mock objects which will add in every story

--- a/src/hooks/useStorage/useStorage.stories.tsx
+++ b/src/hooks/useStorage/useStorage.stories.tsx
@@ -35,6 +35,12 @@ export const DefaultValue: Story = {
     method: 'GET',
   },
   parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders a useReqraftStorage demo where the server returns no stored value — the hook falls back to the default and displays it.',
+      },
+    },
     mockData: [
       {
         url: 'https://hq.qoretechnologies.com:8092/api/latest/users?action=current',
@@ -51,6 +57,12 @@ export const DefaultValue: Story = {
 
 export const StorageValue: Story = {
   parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders a useReqraftStorage demo with a value already persisted on the server — the hook loads it and displays it in place of the default.',
+      },
+    },
     mockData: [...storiesStorageMock],
   },
   play: async () => {
@@ -60,6 +72,15 @@ export const StorageValue: Story = {
 
 export const ValueCanBeUpdated: Story = {
   ...StorageValue,
+  parameters: {
+    ...StorageValue.parameters,
+    docs: {
+      description: {
+        story:
+          'Renders the useReqraftStorage demo with a stored value. When "Update storage" is clicked, the setter writes a new value and the display refreshes to match.',
+      },
+    },
+  },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
 
@@ -74,6 +95,15 @@ export const ValueCanBeUpdated: Story = {
 
 export const ValueCanBeRemoved: Story = {
   ...StorageValue,
+  parameters: {
+    ...StorageValue.parameters,
+    docs: {
+      description: {
+        story:
+          'Renders the useReqraftStorage demo with a stored value. When "Remove value" is clicked, the remover clears storage and the hook falls back to the default value.',
+      },
+    },
+  },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
 

--- a/src/hooks/useWebSocket/useWebsocket.stories.tsx
+++ b/src/hooks/useWebSocket/useWebsocket.stories.tsx
@@ -106,8 +106,25 @@ const meta = {
 export default meta;
 export type Story = StoryObj<typeof meta>;
 
-export const Default: Story = {};
+export const Default: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders the useReqraftWebSocket demo with no lifecycle options — the socket stays CLOSED until the operator clicks Connect.',
+      },
+    },
+  },
+};
 export const OpenManually: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders the useReqraftWebSocket demo and clicks the Connect action — the socket opens and the onOpen callback fires.',
+      },
+    },
+  },
   play: async ({ args }) => {
     await testsClickButton({ label: 'Connect' });
     await testsWaitForText('Websocket Status: OPEN');
@@ -118,6 +135,14 @@ export const OpenOnMount: Story = {
   args: {
     openOnMount: true,
   },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders the useReqraftWebSocket demo with openOnMount enabled — the socket opens immediately after mount without any user action.',
+      },
+    },
+  },
   play: async ({ args }) => {
     await testsWaitForText('Websocket Status: OPEN');
     await expect(args.onOpen).toHaveBeenCalled();
@@ -126,6 +151,15 @@ export const OpenOnMount: Story = {
 
 export const CloseManually: Story = {
   ...OpenOnMount,
+  parameters: {
+    ...OpenOnMount.parameters,
+    docs: {
+      description: {
+        story:
+          'Renders the useReqraftWebSocket demo opened on mount. When Disconnect is clicked, the socket transitions to CLOSED and the onClose callback fires.',
+      },
+    },
+  },
   play: async ({ args, ...rest }) => {
     await OpenOnMount.play({ args, ...rest });
     await testsClickButton({ label: 'Disconnect' });
@@ -140,6 +174,14 @@ export const Reconnects: Story = {
     reconnect: true,
     maxReconnectTries: 5,
     openOnMount: true,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders the useReqraftWebSocket demo with reconnect enabled. When the server is killed, the socket transitions to CONNECTING and then back to OPEN once the server returns.',
+      },
+    },
   },
   play: async ({ args, ...rest }) => {
     await OpenOnMount.play({ args, ...rest });
@@ -159,6 +201,12 @@ export const ReconnectFails: Story = {
     reconnectInterval: 500,
   },
   parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders the useReqraftWebSocket demo with a low maxReconnectTries. When the server never returns, the socket exhausts its reconnect attempts and fires onReconnectFailed.',
+      },
+    },
     jest: {
       timeout: 60000,
     },
@@ -177,6 +225,14 @@ export const SendMessage: Story = {
     ...OpenOnMount.args,
     includeSentMessagesInState: true,
     useState: true,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders the useReqraftWebSocket demo with useState enabled. When Send is clicked, the message is dispatched and the echoed reply appears in the accumulated message list.',
+      },
+    },
   },
   play: async ({ args, ...rest }) => {
     await OpenOnMount.play({ args, ...rest });
@@ -197,6 +253,14 @@ export const WithLogs: Story = {
     useState: true,
     reconnectInterval: 1500,
   },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders the useReqraftWebSocket demo with includeLogMessagesInState. Connect / disconnect / reconnect lifecycle events are captured as log entries alongside regular messages.',
+      },
+    },
+  },
   play: async ({ args, ...rest }) => {
     await Reconnects.play({ args, ...rest });
 
@@ -206,6 +270,15 @@ export const WithLogs: Story = {
 
 export const ClearsMessages: Story = {
   ...SendMessage,
+  parameters: {
+    ...SendMessage.parameters,
+    docs: {
+      description: {
+        story:
+          'Renders the useReqraftWebSocket demo after sending a message. When Clear is clicked, the accumulated message list is emptied.',
+      },
+    },
+  },
   play: async ({ args, ...rest }) => {
     await SendMessage.play({ args, ...rest });
     await testsClickButton({ label: 'Clear' });
@@ -353,6 +426,14 @@ export const MultipleConnections: Story = {
     includeLogMessagesInState: true,
     useState: true,
   },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders three panels that each call useReqraftWebSocket against the same URL — proves the connections share one pooled underlying WebSocket while keeping independent message state.',
+      },
+    },
+  },
   // @ts-expect-error customprops
   render: (args: IUseReqraftWebSocketOptions) => {
     const [conectionStatus, setConnectionStatus] = useState<string>('CLOSED');
@@ -405,6 +486,15 @@ export const MultipleConnectionsOpenOnMount: Story = {
     ...MultipleConnections.args,
     openOnMount: true,
   },
+  parameters: {
+    ...MultipleConnections.parameters,
+    docs: {
+      description: {
+        story:
+          'Renders three pooled useReqraftWebSocket panels with openOnMount — all three transition to OPEN over the shared underlying socket without any user action.',
+      },
+    },
+  },
   play: async ({ args }) => {
     await testsWaitForText('First Connection Status: OPEN');
     await testsWaitForText('Second Connection Status: OPEN');
@@ -419,6 +509,15 @@ export const MultipleConnectionsClosedAtOnce: Story = {
   args: {
     ...MultipleConnections.args,
     openOnMount: true,
+  },
+  parameters: {
+    ...MultipleConnections.parameters,
+    docs: {
+      description: {
+        story:
+          'Renders three pooled useReqraftWebSocket panels. When Close All closes the shared socket, every consumer transitions to CLOSED at once and each panel logs its close handler.',
+      },
+    },
   },
   play: async (args) => {
     await MultipleConnectionsOpenOnMount.play(args);
@@ -435,6 +534,15 @@ export const ConnectionIsClosedWhenAllUsersAreClosed: Story = {
   args: {
     ...MultipleConnections.args,
     openOnMount: true,
+  },
+  parameters: {
+    ...MultipleConnections.parameters,
+    docs: {
+      description: {
+        story:
+          'Renders three pooled useReqraftWebSocket panels. Closing them one by one keeps the shared socket OPEN until the last consumer unmounts, then it closes.',
+      },
+    },
   },
   play: async (args) => {
     await MultipleConnectionsOpenOnMount.play(args);
@@ -453,6 +561,15 @@ export const MultipleConnectionsHaveCustomHandlers: Story = {
   args: {
     ...MultipleConnections.args,
     openOnMount: true,
+  },
+  parameters: {
+    ...MultipleConnections.parameters,
+    docs: {
+      description: {
+        story:
+          'Renders three pooled useReqraftWebSocket panels. Each panel attaches its own message handler, and sending a message triggers the handlers of only the connections still open.',
+      },
+    },
   },
   play: async (args) => {
     const canvas = within(args.canvasElement);
@@ -480,6 +597,15 @@ export const MultipleConnectionsHaveCustomHandlers: Story = {
 
 export const MultipleConnectionsCanBeDisconnectedAndReconnected: Story = {
   ...MultipleConnectionsHaveCustomHandlers,
+  parameters: {
+    ...MultipleConnectionsHaveCustomHandlers.parameters,
+    docs: {
+      description: {
+        story:
+          'Renders three pooled useReqraftWebSocket panels after custom handlers have fired. Disconnecting one and reconnecting another proves individual consumers can toggle without disturbing peers.',
+      },
+    },
+  },
   play: async (args) => {
     await MultipleConnectionsHaveCustomHandlers.play(args);
 

--- a/src/stores/currentUser/currentUser.stories.tsx
+++ b/src/stores/currentUser/currentUser.stories.tsx
@@ -26,6 +26,14 @@ export default meta;
 export type Story = StoryObj<typeof meta>;
 
 export const CurrentUserCanBeLoaded: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders a demo that reads currentUserStore — the store loads /users?action=current and the returned user object is displayed as a tree.',
+      },
+    },
+  },
   play: async () => {
     await testsWaitForText('"David Nichols"');
   },
@@ -33,6 +41,15 @@ export const CurrentUserCanBeLoaded: Story = {
 
 export const CurrentUserHasPermissions: Story = {
   ...CurrentUserCanBeLoaded,
+  parameters: {
+    ...CurrentUserCanBeLoaded.parameters,
+    docs: {
+      description: {
+        story:
+          'Renders a demo that calls currentUserStore().hasAnyPermission — the affirmative message renders because the loaded user carries at least one of the requested permissions.',
+      },
+    },
+  },
   render: () => {
     const { hasAnyPermission } = currentUserStore();
 


### PR DESCRIPTION
## Summary
- Adds `parameters.docs.description.story` to every exported story across all 36 story files under `src/`
- 306 new descriptions on top of 19 that were already in place (SmartEditor, QonsoleSmartInput, DpqlEditor) — 325 stories total now describe their surface
- Surfaces covered: form fields (Boolean, Color, Cron, File, LongString, Markdown, Number, Object, RadioGroup, String), FormEngine (78 stories), hooks (useFetch, useReqraftWebSocket, useReqraftStorage), Menu, Log, Reqore-wrapped editors (SmartEditor, QonsoleSmartInput, DpqlEditor, ExpressionField), standalone reqraft primitives
- Version bump 0.10.10 → 0.10.11 per repo policy (patch bump while in beta)

## Voice / shape
Every description is one sentence, "Renders X. [When Y happens,] shows / does Z." shape, grounded in the story's args / play / meta title. No structural edits — args, argTypes, play, decorators, tags, fixtures, meta blocks, and JSDoc comments preserved verbatim. Existing `parameters.chromatic` settings merged with `docs` as siblings (not clobbered). Live stories that hit the real Qorus LSP rather than a mock call that out in their description.

## Test plan
- [x] `yarn precheck` local — lint + 473 unit tests + build:test:prod all green ✓
- [ ] CI green
- [ ] Storybook Docs tab renders every story description
- [ ] Reviewer confirms voice / accuracy on a sample of stories (especially the 78 FormEngine stories)

🤖 Generated with [Claude Code](https://claude.com/claude-code)