### PR TITLE
fix(storage): write onto the latest blob, not a stale closure copy

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qoretechnologies/reqraft",
-  "version": "0.10.11",
+  "version": "0.10.12",
   "description": "ReQraft is a collection of React components and hooks that are used across Qore Technologies' products made using the ReQore component library from Qore.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/hooks/useStorage/useStorage.stories.tsx
+++ b/src/hooks/useStorage/useStorage.stories.tsx
@@ -1,5 +1,6 @@
 import { ReqoreButton, ReqoreControlGroup, ReqoreP } from '@qoretechnologies/reqore';
 import { StoryObj } from '@storybook/react-vite';
+import { useRef } from 'react';
 import { fireEvent, within } from 'storybook/test';
 import { storiesStorageMock } from '../../../__tests__/ mock';
 import { testsWaitForText } from '../../../__tests__/utils';
@@ -90,6 +91,57 @@ export const ValueCanBeUpdated: Story = {
     await testsWaitForText('Update storage');
     await fireEvent.click(canvas.getByText('Update storage'));
     await testsWaitForText('This is a NEW value');
+  },
+};
+
+/**
+ * Regression for the "stale updater clobbers other keys" bug: the storage
+ * updater must persist onto the LATEST storage blob, not the one captured in
+ * its closure. Long-lived callers (an imperative store subscription, a ref to
+ * the mount-time setter) hold an old updater; writing through it must not wipe
+ * keys other hooks wrote in the meantime.
+ */
+export const StaleUpdaterDoesNotClobberOtherKeys: Story = {
+  args: { reqraftOptions: { waitForStorage: true } },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Renders two useReqraftStorage keys and captures the mount-time setter for the first one (a deliberately STALE updater). After a second key is written, writing through the stale updater must keep the second key intact — proving storage writes merge onto the latest blob rather than a closure copy. This is the regression test for page-visit tracking wiping other stored settings.",
+      },
+    },
+    mockData: [...storiesStorageMock],
+  },
+  render: () => {
+    const [someVal, setSomeVal] = useReqraftStorage<string>('some-path', 'default');
+    const [keyB] = useReqraftStorage<string>('key-b', 'b-default');
+    const [, setKeyB] = useReqraftStorage<string>('key-b', 'b-default');
+    // Capture the mount-time setter — it stays stale once other keys change.
+    const staleSetSomeVal = useRef(setSomeVal);
+
+    return (
+      <ReqoreControlGroup vertical>
+        <ReqoreP>{`some-path: ${someVal}`}</ReqoreP>
+        <ReqoreP>{`key-b: ${keyB}`}</ReqoreP>
+        <ReqoreButton onClick={() => setKeyB('b-written')}>Write B</ReqoreButton>
+        <ReqoreButton onClick={() => staleSetSomeVal.current('a-written')}>
+          Write A (stale)
+        </ReqoreButton>
+      </ReqoreControlGroup>
+    );
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await testsWaitForText('some-path: This is a storage value');
+    // Write a second key through its own (fresh) updater.
+    await fireEvent.click(canvas.getByText('Write B'));
+    await testsWaitForText('key-b: b-written');
+    // Write the first key through the STALE mount-time updater.
+    await fireEvent.click(canvas.getByText('Write A (stale)'));
+    await testsWaitForText('some-path: a-written');
+    // The stale write must NOT have wiped the second key.
+    await testsWaitForText('key-b: b-written');
   },
 };
 

--- a/src/providers/StorageProvider.tsx
+++ b/src/providers/StorageProvider.tsx
@@ -53,26 +53,34 @@ export const ReqraftUserProvider = ({ children, waitForStorage }: IReqraftStorag
       includeAppPrefix: boolean = true
     ) {
       const _path = includeAppPrefix ? `${appName}.${path}` : path;
-      const updatedStorage = set(cloneDeep(currentUser?.storage), _path, value);
+      // Base the write on the LATEST storage read straight from the store, not
+      // the blob captured in this callback's closure. A caller holding a stale
+      // updater — e.g. an imperative store subscription created on mount, before
+      // other keys had loaded — would otherwise persist an out-of-date blob and
+      // wipe every key written to storage since its closure was captured.
+      const latestStorage = currentUserStore.getState().currentUser?.storage;
+      const updatedStorage = set(cloneDeep(latestStorage), _path, value);
 
       updateCurrentUserStorage(updatedStorage);
 
       load({ body: { storage: updatedStorage } });
     },
-    [appName, currentUser?.storage, load, updateCurrentUserStorage]
+    [appName, load, updateCurrentUserStorage]
   );
 
   const removeStorageValue = useCallback(
     function (path: string, includeAppPrefix: boolean = true) {
       const _path = includeAppPrefix ? `${appName}.${path}` : path;
 
-      const updatedStorage = set(cloneDeep(currentUser?.storage), _path, null);
+      // Same as `updateStorage`: mutate the latest blob, never a stale closure copy.
+      const latestStorage = currentUserStore.getState().currentUser?.storage;
+      const updatedStorage = set(cloneDeep(latestStorage), _path, null);
 
       updateCurrentUserStorage(updatedStorage);
 
       load({ body: { storage_path: _path } });
     },
-    [appName, currentUser?.storage, load, updateCurrentUserStorage]
+    [appName, load, updateCurrentUserStorage]
   );
 
   const contextValue = useMemo(


### PR DESCRIPTION
## Symptom

Every navigation that persisted a value (e.g. a page-visit counter that writes on each route change) **wiped other stored settings**. In qorus-ide this surfaced as storage items disappearing every time the user changed pages.

## Root cause

`ReqraftUserProvider.updateStorage` / `removeStorageValue` build the new storage from the `currentUser.storage` captured in their `useCallback` **closure**, then PUT the *entire* blob:

```ts
const updatedStorage = set(cloneDeep(currentUser?.storage), _path, value); // <- closure copy
```

Any caller holding a **stale updater** — most commonly an imperative store subscription created on mount (`useEffect(() => store.subscribe(...), [])`), before other keys had loaded — persists an out-of-date blob and clobbers every key written since its closure was captured.

## Fix

Read the latest storage **synchronously from the store** at write time instead of the closure:

```ts
const latestStorage = currentUserStore.getState().currentUser?.storage;
const updatedStorage = set(cloneDeep(latestStorage), _path, value);
```

Writes now always merge onto the current blob, immune to stale/long-lived updaters. The callbacks no longer depend on `currentUser?.storage`, so they're also stable identities.

## Test

New regression story **`Hooks/useStorage › StaleUpdaterDoesNotClobberOtherKeys`**: captures a mount-time (stale) updater, writes a second key through a fresh updater, then writes through the stale one and asserts the second key survives. Verified it **fails on the old closure-based code and passes with the fix**. `yarn precheck`: lint clean, 473 tests pass, prod build clean.

## Version
`0.10.11` → `0.10.12` (patch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)