### PR TITLE
fix(storage): seed a fresh object so a user's first storage write isn't dropped

### DIFF
--- a/__tests__/storageProvider.test.ts
+++ b/__tests__/storageProvider.test.ts
@@ -1,0 +1,43 @@
+/**
+ * Regression coverage for the "cookie-consent banner never closes" bug.
+ *
+ * A user with no storage yet has `currentUser.storage === undefined | null`.
+ * `set(cloneDeep(undefined), path, value)` returns `undefined` (lodash won't set
+ * on a nullish target), so the FIRST write for such a user — accepting the
+ * cookie-consent banner, the first onboarding flag, etc. — persisted an empty
+ * body and silently dropped the value, leaving the flag unset forever (the banner
+ * reappeared on every load). `applyStorageWrite` seeds a fresh `{}` so the first
+ * write builds real storage.
+ */
+import { applyStorageWrite } from '../src/providers/StorageProvider';
+
+describe('applyStorageWrite', () => {
+  test('seeds a fresh object when storage is undefined (the first-ever write)', () => {
+    expect(applyStorageWrite(undefined, 'ide.cookie-consent', true)).toEqual({
+      ide: { 'cookie-consent': true },
+    });
+  });
+
+  test('seeds a fresh object when storage is null', () => {
+    expect(applyStorageWrite(null as unknown as undefined, 'ide.onboarded', true)).toEqual({
+      ide: { onboarded: true },
+    });
+  });
+
+  test('merges onto existing storage without dropping other keys', () => {
+    expect(applyStorageWrite({ a: 1, ide: { x: 1 } }, 'ide.y', 2)).toEqual({
+      a: 1,
+      ide: { x: 1, y: 2 },
+    });
+  });
+
+  test('clones — never mutates the input blob', () => {
+    const input = { ide: { x: 1 } };
+    applyStorageWrite(input, 'ide.y', 2);
+    expect(input).toEqual({ ide: { x: 1 } });
+  });
+
+  test('supports removal writes (value = null) on nullish storage too', () => {
+    expect(applyStorageWrite(undefined, 'ide.gone', null)).toEqual({ ide: { gone: null } });
+  });
+});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qoretechnologies/reqraft",
-  "version": "0.10.12",
+  "version": "0.10.13",
   "description": "ReQraft is a collection of React components and hooks that are used across Qore Technologies' products made using the ReQore component library from Qore.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/providers/StorageProvider.tsx
+++ b/src/providers/StorageProvider.tsx
@@ -9,6 +9,23 @@ import { TReqraftStorageValue } from '../hooks/useStorage/useStorage';
 import { currentUserStore } from '../stores/currentUser/currentUser';
 import { IReqraftProviderProps } from './ReqraftProvider';
 
+/**
+ * Apply a single path write onto the current storage blob, seeding a fresh object
+ * when the user has no storage yet.
+ *
+ * `?? {}` is load-bearing: a user who has never written storage has
+ * `storage === undefined | null`, and `set(cloneDeep(undefined), …)` returns
+ * `undefined` (lodash won't set on a nullish target). Without the seed the FIRST
+ * write for such a user — e.g. accepting the cookie-consent banner — persists an
+ * empty body and silently drops the value, so the flag stays unset forever and
+ * the banner never closes. Exported for testing.
+ */
+export const applyStorageWrite = (
+  storage: TReqraftStorage | undefined,
+  path: string,
+  value: unknown
+): TReqraftStorage => set(cloneDeep(storage) ?? {}, path, value);
+
 export interface IReqraftStorageProviderProps
   extends Pick<IReqraftProviderProps, 'waitForStorage'> {
   children: ReactNode;
@@ -59,7 +76,7 @@ export const ReqraftUserProvider = ({ children, waitForStorage }: IReqraftStorag
       // other keys had loaded — would otherwise persist an out-of-date blob and
       // wipe every key written to storage since its closure was captured.
       const latestStorage = currentUserStore.getState().currentUser?.storage;
-      const updatedStorage = set(cloneDeep(latestStorage), _path, value);
+      const updatedStorage = applyStorageWrite(latestStorage, _path, value);
 
       updateCurrentUserStorage(updatedStorage);
 
@@ -72,9 +89,10 @@ export const ReqraftUserProvider = ({ children, waitForStorage }: IReqraftStorag
     function (path: string, includeAppPrefix: boolean = true) {
       const _path = includeAppPrefix ? `${appName}.${path}` : path;
 
-      // Same as `updateStorage`: mutate the latest blob, never a stale closure copy.
+      // Same as `updateStorage`: mutate the LATEST blob (never a stale closure
+      // copy), seeding a fresh object when there's no storage yet.
       const latestStorage = currentUserStore.getState().currentUser?.storage;
-      const updatedStorage = set(cloneDeep(latestStorage), _path, null);
+      const updatedStorage = applyStorageWrite(latestStorage, _path, null);
 
       updateCurrentUserStorage(updatedStorage);
 


### PR DESCRIPTION
## Symptom

On a fresh account (reproduced against a SaaS user on spinster), the **cookie-consent banner never closes** — clicking *Understood* fires a request with an **empty body**, the flag never persists, and the banner reappears on every reload, blocking the user.

## Root cause

`ReqraftUserProvider.updateStorage` / `removeStorageValue` did:

```ts
const latestStorage = currentUserStore.getState().currentUser?.storage; // undefined for a new user
const updatedStorage = set(cloneDeep(latestStorage), path, value);       // => undefined
```

A user who has never written storage has `storage === undefined | null`, and lodash `set` **won't set on a nullish target** — it returns it unchanged. So `updatedStorage` is `undefined`, the optimistic local update sets storage back to `undefined`, and the PUT body is empty. `getStorage('cookie-consent')` then stays at its default `false` forever.

This affects **any** first-ever write for such a user (onboarding flags, etc.), not just the cookie banner. It stayed hidden because most existing users already had non-empty server storage.

## Fix

Extract the merge into a pure, exported `applyStorageWrite(storage, path, value)` that seeds a fresh object when storage is nullish:

```ts
set(cloneDeep(storage) ?? {}, path, value)
```

and route both writers through it. `undefined`/`null`/`{}` all now build real storage.

## Coverage

- New `__tests__/storageProvider.test.ts`: nullish-storage seeding, merge-without-dropping-keys, no-mutation, and removal-on-nullish cases.
- `yarn precheck` green: lint + 478 unit tests + prod typecheck.
- Patch bump `0.10.12` → `0.10.13`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)