### PR TITLE
feat(form-engine): let consumers prop-control the compact panel

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qoretechnologies/reqraft",
-  "version": "0.10.13",
+  "version": "0.10.14",
   "description": "ReQraft is a collection of React components and hooks that are used across Qore Technologies' products made using the ReQore component library from Qore.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -56,7 +56,7 @@
     "@chromatic-com/storybook": "^5.2.1",
     "@netsells/storybook-mockdate": "^0.3.3",
     "@qoretechnologies/qlip": "^0.1.3-beta.20260622084321",
-    "@qoretechnologies/reqore": "^0.70.6",
+    "@qoretechnologies/reqore": "^0.71.6",
     "@storybook/addon-docs": "^10.4.6",
     "@storybook/addon-links": "^10.4.6",
     "@storybook/addon-vitest": "^10.4.6",

--- a/src/components/form/engine/CompactToolbar.tsx
+++ b/src/components/form/engine/CompactToolbar.tsx
@@ -4,15 +4,15 @@ import {
   ReqoreDropdown,
   ReqoreInput,
 } from '@qoretechnologies/reqore';
-import { useReqoreTheme } from '@qoretechnologies/reqore/dist/hooks/useTheme';
 import { IReqoreControlGroupProps } from '@qoretechnologies/reqore/dist/components/ControlGroup';
 import {
   IReqoreDropdownItem,
   TReqoreDropdownItems,
 } from '@qoretechnologies/reqore/dist/components/Dropdown/list';
+import { useReqoreTheme } from '@qoretechnologies/reqore/dist/hooks/useTheme';
 import React, { memo } from 'react';
-import { useContext } from 'use-context-selector';
 import styled from 'styled-components';
+import { useContext } from 'use-context-selector';
 import { CompactToolbarContext, TCompactSort } from './compactToolbarContext';
 
 // Field sort modes, listed in the Fields menu's "Sort by" submenu. 'schema' is
@@ -40,7 +40,13 @@ const StyledCompletionLine = styled.div`
   gap: 10px;
   flex-wrap: wrap;
 `;
-const StyledMeter = styled.div<{ $set: number; $attention: number; $track: string; $set_c: string; $att_c: string }>`
+const StyledMeter = styled.div<{
+  $set: number;
+  $attention: number;
+  $track: string;
+  $set_c: string;
+  $att_c: string;
+}>`
   position: relative;
   height: 4px;
   border-radius: 3px;
@@ -180,114 +186,115 @@ export const CompactToolbar = memo((reqoreProps: Partial<IReqoreControlGroupProp
       {hasMultipleOptions || (invalidCount && !readOnly) ?
         <ReqoreControlGroup vertical fluid gapSize='normal'>
           {hasMultipleOptions ?
-          <ReqoreControlGroup fluid verticalAlign='center'>
-          <ReqoreInput
-            fluid
-            pill
-            icon='Search2Line'
-            iconColor='muted'
-            placeholder='Filter fields...'
-            value={compactQuery}
-            intent={compactQuery ? 'info' : undefined}
-            className='options-readfirst-search'
-            onChange={(event: React.FormEvent<HTMLInputElement>) =>
-              setCompactQuery(event.currentTarget.value)
-            }
-            onClearClick={() => setCompactQuery('')}
-          />
-          {!readOnly ?
-            <ReqoreDropdown
-              fixed
-              flat
-              filterable
-              icon='Filter3Line'
-              tooltip='Fields'
-              className='options-readfirst-fields'
-              intent={requiredOnly ? 'info' : undefined}
-              badge={requiredOnly ? 'Required only' : undefined}
-              onItemSelect={(item: IReqoreDropdownItem) =>
-                item.value && onAddOptionalField(item.value)
-              }
-              items={
-                [
-                  {
-                    label: 'Required only',
-                    selected: requiredOnly,
-                    icon: requiredOnly ? 'CheckboxCircleLine' : 'CheckboxBlankCircleLine',
-                    tooltip: 'Show only required fields',
-                    onClick: () => setRequiredOnly((value) => !value),
-                  },
-                  {
-                    label: 'Show field types',
-                    selected: showFieldTypes,
-                    icon: showFieldTypes ? 'CheckboxCircleLine' : 'CheckboxBlankCircleLine',
-                    tooltip: 'Annotate each field with its type',
-                    onClick: onToggleFieldTypes,
-                  },
-                  // Sort by — a submenu (collapsed by default) so the five modes
-                  // don't crowd the Fields menu. Reorders fields WITHIN each group
-                  // (groups + required-group rails preserved); the active non-
-                  // default mode shows as a badge on the parent.
-                  {
-                    label: 'Sort by',
-                    icon: 'ArrowUpDownLine',
-                    intent: compactSort !== 'schema' ? 'info' : undefined,
-                    badge:
-                      compactSort !== 'schema' ?
-                        SORT_MODES.find((mode) => mode.value === compactSort)?.label
-                      : undefined,
-                    items: SORT_MODES.map((mode) => ({
-                      label: mode.label,
-                      tooltip: mode.tooltip,
-                      selected: compactSort === mode.value,
-                      icon:
-                        compactSort === mode.value ?
-                          'CheckboxCircleLine'
-                        : 'CheckboxBlankCircleLine',
-                      onClick: () => setCompactSort(mode.value),
-                    })),
-                  },
-                  {
-                    label: 'Select all',
-                    icon: 'MenuAddLine',
-                    tooltip: 'Add every optional field',
-                    disabled: filteredCount === 0,
-                    onClick: onAddAll,
-                  },
-                  {
-                    label: 'Default fields',
-                    icon: 'RestartLine',
-                    tooltip: 'Reset to the default set of fields',
-                    onClick: onResetDefaults,
-                  },
-                  {
-                    label: 'Revert all changes',
-                    icon: 'HistoryLine',
-                    tooltip: 'Undo all edits back to the loaded values',
-                    disabled: !canRevert,
-                    onClick: onRevertAll,
-                  },
-                  // The individual not-yet-added fields are no longer listed here —
-                  // they render as addable rows in the Optional box instead. The
-                  // menu keeps only the bulk actions above (Select all / Default
-                  // fields / filters).
-                ] as TReqoreDropdownItems
-              }
-            />
+            <ReqoreControlGroup fluid verticalAlign='center'>
+              <ReqoreInput
+                fluid
+                pill
+                icon='Search2Line'
+                iconColor='muted'
+                placeholder='Filter fields...'
+                value={compactQuery}
+                intent={compactQuery ? 'info' : undefined}
+                className='options-readfirst-search'
+                onChange={(event: React.FormEvent<HTMLInputElement>) =>
+                  setCompactQuery(event.currentTarget.value)
+                }
+                onClearClick={() => setCompactQuery('')}
+              />
+              {!readOnly ?
+                <ReqoreDropdown
+                  fixed
+                  flat
+                  filterable
+                  icon='Filter3Line'
+                  tooltip='Fields'
+                  className='options-readfirst-fields'
+                  intent={requiredOnly ? 'info' : undefined}
+                  badge={requiredOnly ? 'Required only' : undefined}
+                  onItemSelect={(item: IReqoreDropdownItem) =>
+                    item.value && onAddOptionalField(item.value)
+                  }
+                  items={
+                    [
+                      {
+                        label: 'Required only',
+                        selected: requiredOnly,
+                        icon: requiredOnly ? 'CheckboxCircleLine' : 'CheckboxBlankCircleLine',
+                        tooltip: 'Show only required fields',
+                        onClick: () => setRequiredOnly((value) => !value),
+                      },
+                      {
+                        label: 'Show field types',
+                        selected: showFieldTypes,
+                        icon: showFieldTypes ? 'CheckboxCircleLine' : 'CheckboxBlankCircleLine',
+                        tooltip: 'Annotate each field with its type',
+                        onClick: onToggleFieldTypes,
+                      },
+                      // Sort by — a submenu (collapsed by default) so the five modes
+                      // don't crowd the Fields menu. Reorders fields WITHIN each group
+                      // (groups + required-group rails preserved); the active non-
+                      // default mode shows as a badge on the parent.
+                      {
+                        label: 'Sort by',
+                        icon: 'ArrowUpDownLine',
+                        intent: compactSort !== 'schema' ? 'info' : undefined,
+                        badge:
+                          compactSort !== 'schema' ?
+                            SORT_MODES.find((mode) => mode.value === compactSort)?.label
+                          : undefined,
+                        items: SORT_MODES.map((mode) => ({
+                          label: mode.label,
+                          tooltip: mode.tooltip,
+                          selected: compactSort === mode.value,
+                          icon:
+                            compactSort === mode.value ?
+                              'CheckboxCircleLine'
+                            : 'CheckboxBlankCircleLine',
+                          onClick: () => setCompactSort(mode.value),
+                        })),
+                      },
+                      {
+                        label: 'Select all',
+                        icon: 'MenuAddLine',
+                        tooltip: 'Add every optional field',
+                        disabled: filteredCount === 0,
+                        onClick: onAddAll,
+                      },
+                      {
+                        label: 'Default fields',
+                        icon: 'RestartLine',
+                        tooltip: 'Reset to the default set of fields',
+                        onClick: onResetDefaults,
+                      },
+                      {
+                        label: 'Revert all changes',
+                        icon: 'HistoryLine',
+                        tooltip: 'Undo all edits back to the loaded values',
+                        disabled: !canRevert,
+                        onClick: onRevertAll,
+                      },
+                      // The individual not-yet-added fields are no longer listed here —
+                      // they render as addable rows in the Optional box instead. The
+                      // menu keeps only the bulk actions above (Select all / Default
+                      // fields / filters).
+                    ] as TReqoreDropdownItems
+                  }
+                />
+              : null}
+              <ReqoreButton
+                fixed
+                flat
+                minimal={showAllDescriptions === true}
+                icon={showAllDescriptions ? 'InformationFill' : 'InformationLine'}
+                className='options-readfirst-descriptions'
+                intent={showAllDescriptions ? 'info' : undefined}
+                tooltip={
+                  showAllDescriptions ? 'Hide all field information' : 'Show all field information'
+                }
+                onClick={onToggleAllDescriptions}
+              />
+            </ReqoreControlGroup>
           : null}
-          <ReqoreButton
-            fixed
-            flat
-            minimal={showAllDescriptions === true}
-            icon={showAllDescriptions ? 'InformationFill' : 'InformationLine'}
-            className='options-readfirst-descriptions'
-            active={showAllDescriptions}
-            intent={showAllDescriptions ? 'info' : undefined}
-            tooltip={showAllDescriptions ? 'Hide all field information' : 'Show all field information'}
-            onClick={onToggleAllDescriptions}
-          />
-        </ReqoreControlGroup>
-      : null}
         </ReqoreControlGroup>
       : null}
     </ReqoreControlGroup>

--- a/src/components/form/engine/FormEngine.stories.tsx
+++ b/src/components/form/engine/FormEngine.stories.tsx
@@ -1680,6 +1680,33 @@ export const Compact: Story = {
   },
 };
 
+export const CompactWithPanelProps: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Renders the Compact fixture with `compactPanelProps` — the read-first form's outer ReqorePanel is dressed from the outside with a label, icon, intent and an extra header action. The engine's own toolbar survives: `actions` append after it and `contentStyle` merges over the engine's flex-column layout instead of replacing either.",
+      },
+    },
+  },
+  args: {
+    ...Compact.args,
+    compactPanelProps: {
+      label: 'Connection settings',
+      icon: 'Settings3Line',
+      intent: 'info',
+      actions: [{ label: 'Docs', icon: 'BookLine', responsive: false }],
+    },
+  },
+  play: async () => {
+    // The outside-supplied panel chrome renders…
+    await _testsWaitForText('Connection settings');
+    await _testsWaitForText('Docs');
+    // …and the engine's own toolbar + rows are untouched by it.
+    await _testsWaitForText('order-fulfilment');
+  },
+};
+
 export const CompactReadOnly: Story = {
   parameters: {
     docs: {

--- a/src/components/form/engine/FormEngine.tsx
+++ b/src/components/form/engine/FormEngine.tsx
@@ -21,13 +21,13 @@ import {
 } from '@qoretechnologies/reqore/dist/components/Panel';
 import { IReqoreFormTemplates } from '@qoretechnologies/reqore/dist/components/Textarea';
 import { TReqoreIntent } from '@qoretechnologies/reqore/dist/constants/theme';
-import { IReqoreIconName } from '@qoretechnologies/reqore/dist/types/icons';
 import {
   changeDarkness,
   getMainBackgroundColor,
   getReadableColor,
   percentToHexAlpha,
 } from '@qoretechnologies/reqore/dist/helpers/colors';
+import { IReqoreIconName } from '@qoretechnologies/reqore/dist/types/icons';
 import {
   IQorusFormField,
   IQorusFormFieldMessage,
@@ -48,11 +48,10 @@ import reduce from 'lodash/reduce';
 import size from 'lodash/size';
 import React, { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { useMeasure, useMount, useUpdateEffect } from 'react-use';
-import { createContext } from 'use-context-selector';
 import styled from 'styled-components';
+import { createContext } from 'use-context-selector';
 import { getDefaultValue, insertAtIndex, richtextToString } from '../../../helpers/common';
 import { getRequiredOptionMessage } from '../../../helpers/options';
-import { query } from '../../../utils/fetch';
 import {
   IValidationResult,
   hasAllDependenciesFullfilled,
@@ -61,6 +60,7 @@ import {
 } from '../../../helpers/validations';
 import { useQorusTypes } from '../../../hooks/useQorusTypes';
 import { useTemplates } from '../../../hooks/useTemplates';
+import { query } from '../../../utils/fetch';
 import { Description } from '../../Description';
 import { FocusedEditing } from '../../FocusedEditing';
 import { SelectFormField } from '../fields/select/Select';
@@ -72,12 +72,6 @@ import {
 } from '../fields/template/TemplateField';
 import { CompactRow } from './CompactRow';
 import { CompactRowContext, ICompactRowContext } from './compactRowContext';
-import { CompactToolbar } from './CompactToolbar';
-import {
-  CompactToolbarContext,
-  ICompactToolbarContext,
-  TCompactSort,
-} from './compactToolbarContext';
 import {
   GROUP_INDENT,
   LABEL_COL_MAX,
@@ -91,9 +85,16 @@ import {
   StyledStatusBox,
   StyledStatusBoxGroupLabel,
 } from './compactRowStyles';
+import { CompactToolbar } from './CompactToolbar';
+import {
+  CompactToolbarContext,
+  ICompactToolbarContext,
+  TCompactSort,
+} from './compactToolbarContext';
 import { OptionFieldMessages } from './OptionFieldMessages';
 import { OptionsHelpDialog } from './OptionsHelpDialog';
 import {
+  TReadFirstStatus,
   getFirstAttentionOptionName,
   getOptionGroup,
   getOptionGroupLabel,
@@ -101,7 +102,6 @@ import {
   getReadFirstCompletion,
   getReadFirstStatus,
   isOptionValueEmpty,
-  TReadFirstStatus,
 } from './readFirst';
 
 // Re-export types for consumers
@@ -201,13 +201,6 @@ const StyledCompactWrap = styled.div<{ $flush?: boolean }>`
      engage instead of overflowing the container horizontally. */
   min-width: 0;
   max-width: 100%;
-  /* A bit of horizontal breathing room for the whole form (header + content
-     alike). Horizontal only — top padding would break the sticky toolbar's
-     flush pin (see the scroll-context note below). Dropped to flush via the
-     compactFlush prop, for embeds that own their own gutters (e.g. the
-     SchemaDefinition tab body). */
-  padding: ${({ $flush }) => ($flush ? '0' : '0 12px')};
-
   /* Own our scroll context instead of borrowing the host's. The sticky toolbar
      pins to whatever scrolls; if that scroller carries top padding (e.g. a
      ReqorePanel/ReqoreContent body), sticky \`top: 0\` resolves against its
@@ -525,6 +518,18 @@ export interface IFormEngineProps extends Omit<IReqoreCollectionProps, 'onChange
    * transparently inside the parent's edit card. Default `false`.
    */
   compactNested?: boolean;
+  /**
+   * Compact mode only: props forwarded to the read-first form's outer
+   * `ReqorePanel` — the panel that carries the sticky toolbar header and holds
+   * the status boxes. Spread AFTER the engine's own defaults, so anything set
+   * here wins (`flat`, `raised`, `minimal`, `stickyHeader`, `label`, `icon`,
+   * `intent`, `padded`, `size`, …). Two props merge instead of replacing, so a
+   * consumer can add to the panel without dismantling the form:
+   * - `actions` — appended after the engine's toolbar action.
+   * - `contentStyle` — merged over the engine's flex-column layout.
+   * No-op in classic (non-compact) mode.
+   */
+  compactPanelProps?: IReqorePanelProps;
   /** Compact mode only: per-group display metadata (label / icon / subtitle /
    * order) — the server only sends the bare group key. */
   groups?: Record<string, IFormEngineGroup>;
@@ -609,6 +614,7 @@ export const FormEngine = ({
   compact,
   compactFlush = false,
   compactNested = false,
+  compactPanelProps,
   commitMode = 'immediate',
   expandMode = 'single',
   onCommit,
@@ -1709,8 +1715,13 @@ export const FormEngine = ({
         <>
           {(() => {
             const schemaMsgs = (
-              suppressSchemaMessages ? [] : (options?.[optionName] as any)?.messages || []
-            ) as { intent?: string; title?: string; content?: string }[];
+              suppressSchemaMessages ?
+                []
+              : (options?.[optionName] as any)?.messages || []) as {
+              intent?: string;
+              title?: string;
+              content?: string;
+            }[];
             if (!schemaMsgs.length) return null;
             const items = schemaMsgs.map(({ intent, title, content }, index) => (
               <ReqoreMessage
@@ -2114,7 +2125,13 @@ export const FormEngine = ({
     ]
   );
 
-  const compactHeaderActions = useMemo(() => [{ as: CompactToolbar, responsive: false }], []);
+  // The engine's own toolbar action, plus whatever the consumer added through
+  // `compactPanelProps.actions` — appended, so an outside action can never
+  // knock the form's toolbar out of the header.
+  const compactHeaderActions = useMemo(
+    () => [{ as: CompactToolbar, responsive: false }, ...(compactPanelProps?.actions || [])],
+    [compactPanelProps?.actions]
+  );
   const renderCompact = () => {
     const headerBg = `${changeDarkness(getMainBackgroundColor(theme), 0.02)}${percentToHexAlpha(88)}`;
     // Toolbar filters narrow the listed rows; the meter reflects the full set.
@@ -2357,22 +2374,24 @@ export const FormEngine = ({
                   $headerBg={compactNested ? 'transparent' : headerBg}
                   $nested={compactNested}
                   flat
+                  raised
+                  minimal
                   // No panel background: the form sits transparently on whatever
                   // hosts it (page, drawer, or — for an arg_schema field — the
                   // parent's edit card) instead of stacking its own dark surface.
                   // The status boxes keep their own tints; the sticky toolbar keeps
                   // its blurred header via the $headerBg override.
-                  transparent
                   stickyHeader={!compactNested}
-                  padded={false}
+                  // Consumer overrides land last so they win over every default
+                  // above; `actions` and `contentStyle` below merge rather than
+                  // replace (see `compactPanelProps`).
+                  {...compactPanelProps}
                   actions={compactHeaderActions}
                   contentStyle={{
                     display: 'flex',
                     flexFlow: 'column',
                     gap: '10px',
-                    // Nested sub-form: no surrounding panel padding (it's flush in
-                    // the parent card); top-level keeps a small bottom gutter.
-                    padding: compactNested ? '0' : '0 0 12px',
+                    ...compactPanelProps?.contentStyle,
                   }}
                 >
                   {size(groupKeys) === 0 ?

--- a/src/components/form/engine/compactRowStyles.ts
+++ b/src/components/form/engine/compactRowStyles.ts
@@ -47,14 +47,13 @@ export const StyledCompactPanel = styled(ReqorePanel)<{
   $nested?: boolean;
 }>`
   > .reqore-panel-title {
-    background: ${({ $headerBg }) => $headerBg};
     /* The blur + translateZ exist only to make the STICKY top-level toolbar ghost
        content beneath it; a nested sub-form's header isn't sticky, so skip them
        (and the stacking context translateZ creates). */
     ${({ $nested }) =>
-      $nested ?
-        ''
-      : 'backdrop-filter: blur(6px); -webkit-backdrop-filter: blur(6px); transform: translateZ(0);'}
+      $nested ? '' : (
+        'backdrop-filter: blur(6px); -webkit-backdrop-filter: blur(6px); transform: translateZ(0);'
+      )}
     padding-top: ${GAP_FROM_SIZE[HEADER_GAP]}px;
     padding-bottom: ${GAP_FROM_SIZE[HEADER_GAP]}px;
   }
@@ -625,5 +624,4 @@ export const StyledGroupBody = styled.div<{
     padding-top: 0;
     padding-bottom: 0;
   }
-
 `;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1384,10 +1384,10 @@
   resolved "https://registry.yarnpkg.com/@qoretechnologies/qlip/-/qlip-0.1.3-beta.20260622084321.tgz#4e66b90e6eb84692795f28ad0469d9caeb58ed94"
   integrity sha512-HGjwZKsIdx00GTg+drTsWWXtY6EX9u8E3HuFxW+KYH1vG2jsTfZwlpCJ2m7tB5AW72Nbt/A8aNjJ14Hph03LiQ==
 
-"@qoretechnologies/reqore@^0.70.6":
-  version "0.70.6"
-  resolved "https://registry.yarnpkg.com/@qoretechnologies/reqore/-/reqore-0.70.6.tgz#07237c7659b4a5a26c0fc8f09a6caf6815fec2ae"
-  integrity sha512-q8TlvJpJF+fM1kcjQU5oeyVGSUG7nUzhfXGNgFZCNQmohSlW+6U/xbtuSEpepxRlXaX5UpHdC49WMTNACiPTsw==
+"@qoretechnologies/reqore@^0.71.6":
+  version "0.71.6"
+  resolved "https://registry.yarnpkg.com/@qoretechnologies/reqore/-/reqore-0.71.6.tgz#bf4e8a8e3c8887e6299bc40285270d045a12cf02"
+  integrity sha512-BPSfROlDjsHDAFBhx2TsLPFC3YMAxVcqsl50xt6pRwhC+WuNPgcVSk3SEPn0ZXvWcfCV7fdhmDUkdXGhnyZzQw==
   dependencies:
     "@internationalized/date" "^3.5.3"
     "@popperjs/core" "^2.11.6"


### PR DESCRIPTION
## What

The read-first (compact) form renders its rows inside one outer `ReqorePanel` — `StyledCompactPanel` — that carried a hard-coded set of panel props. A consumer embedding `FormEngine` could not give that panel a label, an icon, an intent, a badge, or its own header action; the only way to dress the surface was to wrap the engine in a *second* panel, which stacked two chromes and broke the sticky toolbar's flush pin.

This PR adds **`compactPanelProps?: IReqorePanelProps`**.

```tsx
<FormEngine
  compact
  compactPanelProps={{
    label: 'Connection settings',
    icon: 'Settings3Line',
    intent: 'info',
    actions: [{ label: 'Docs', icon: 'BookLine' }],
  }}
/>
```

- **Spread after the engine's own defaults**, so anything the consumer sets wins (`flat`, `raised`, `minimal`, `stickyHeader`, `label`, `icon`, `intent`, `padded`, `size`, badges, …).
- **`actions` append** after the engine's own `CompactToolbar` action, so an outside action can never knock the form's toolbar out of the header.
- **`contentStyle` merges** over the engine's flex-column layout instead of replacing it.
- The transient styling props (`$headerBg`, `$nested`) stay engine-owned — they aren't part of `IReqorePanelProps`, so the type rejects them.
- No-op in classic (non-compact) mode.

This is the Reqore-first path for this surface: reach for the panel's own props rather than wrapping it in another styled surface.

## Also on this branch (in-flight work carried in with it)

- **reqore `0.70.6` → `0.71.6`**, and the compact panel moves to `flat raised minimal` (dropping `transparent` / `padded={false}` and the wrap's 12px horizontal gutter) so the read-first surface sits on the host background.
- **CompactToolbar**: drop the `active` prop from the descriptions toggle (`intent` already carries the on-state) + reformat.

## Testing

- New story: `Form/Engine/FormEngine · CompactWithPanelProps` — dresses the panel from the outside and asserts the engine's own toolbar and rows survive.
- Local Qlip capture of the new story read and verified (capture dir deleted afterwards).
- `yarn test` — 478 passed. `yarn build:test:prod` + `yarn lint` — clean.
- `yarn test:stories` over the six FormEngine-bound story files — 120 passed; 3 fail **locally only** (`Option With Any Type`, `Toggle In Form Engine`, `Via Form Engine Ui Type`). Those three need a live Qorus instance (`REACT_APP_QORUS_TOKEN`, supplied in CI by secrets); verified they fail identically against reqore 0.70.6 and 0.71.6, so they are not caused by this diff.

Version bumped `0.10.13` → `0.10.14`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)