### PR TITLE
fix(form-engine): make focused editing work on inline compact rows

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qoretechnologies/reqraft",
-  "version": "0.10.14",
+  "version": "0.10.15",
   "description": "ReQraft is a collection of React components and hooks that are used across Qore Technologies' products made using the ReQore component library from Qore.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/components/FocusedEditing/index.tsx
+++ b/src/components/FocusedEditing/index.tsx
@@ -2,7 +2,22 @@ import { IReqoreModalProps, ReqoreModal } from '@qoretechnologies/reqore/dist/co
 import { memo, useCallback, useEffect, useState } from 'react';
 
 export const FocusedEditing = memo(
-  ({ children, isFullscreen, ...rest }: IReqoreModalProps & { isFullscreen?: boolean }) => {
+  ({
+    children,
+    isFullscreen,
+    modalOnly,
+    ...rest
+  }: IReqoreModalProps & {
+    isFullscreen?: boolean;
+    /**
+     * Render ONLY the modal, not the in-place copy of `children`. For call
+     * sites that already render the field themselves and just need the focused
+     * overlay on top — e.g. the compact row's inline editor, which lives in the
+     * row grid and must stay there. Default (`false`) renders children in place
+     * as well, which is what the classic and card layouts wrap themselves in.
+     */
+    modalOnly?: boolean;
+  }) => {
     const [_isFullscreen, setIsFullscreen] = useState(isFullscreen);
 
     const handleFullscreenToggle = useCallback(() => {
@@ -28,7 +43,7 @@ export const FocusedEditing = memo(
             {children}
           </ReqoreModal>
         )}
-        {children}
+        {modalOnly ? null : children}
       </>
     );
   }

--- a/src/components/form/engine/CompactRow.tsx
+++ b/src/components/form/engine/CompactRow.tsx
@@ -573,6 +573,30 @@ export const CompactRow = memo(
     // "descriptions" toggle is engaged (and inside the editor when expanded).
     const showLabelDesc = !!labelShortDesc && showAllDescriptions === true;
 
+    // The `?` that opens the long-form help dialog. Shared by the read row AND
+    // the inline editor: opening a field used to drop it, leaving an editing row
+    // with no route to the field's description at all. Stops propagation because
+    // both labels are click targets themselves (the row expands / collapses).
+    const helpIcon =
+      schema?.desc ?
+        <ReqoreIcon
+          icon='QuestionLine'
+          size='12px'
+          effect={{ opacity: 0.55 }}
+          margin='left'
+          marginSize='tiny'
+          role='button'
+          tabIndex={-1}
+          aria-label='Help'
+          className='options-readfirst-help'
+          style={{ cursor: 'help' }}
+          onClick={(event) => {
+            event.stopPropagation();
+            handleOptionLabelClick(optionName);
+          }}
+        />
+      : null;
+
     const renderInfoStrip = (m: TInfoMsg, index: number) => (
       <ReqoreMessage
         key={`${m.content}-${index}`}
@@ -688,11 +712,13 @@ export const CompactRow = memo(
               >
                 {label}
                 {required ? <ReqoreIcon icon='Asterisk' color='danger' size='10px' /> : null}
+                {helpIcon}
               </StyledRowLabel>
-              {/* Keep the short_desc visible while editing inline when the global
-                  descriptions toggle is on — read rows show it, so opening a field
-                  shouldn't make it vanish. */}
-              {showLabelDesc ?
+              {/* An OPEN field always shows its short_desc — that's where the hint
+                  is needed and there's no per-row button to reveal it (the edit
+                  card does the same). The global descriptions toggle governs READ
+                  rows only, so collapsing the field is what hides it again. */}
+              {labelShortDesc ?
                 <StyledLabelDesc
                   className='options-readfirst-label-desc'
                   size='small'
@@ -753,6 +779,27 @@ export const CompactRow = memo(
             className={clusterBlockClass || undefined}
           >
             {editingRow}
+            {/* Focused editing for an INLINE row. The edit card wraps its editor
+                in <FocusedEditing>, which renders the field in place AND in the
+                modal; an inline row already renders its editor in the row grid,
+                so it mounts the modal alone. Without this the More menu's "Edit
+                fullscreen" set the state and nothing appeared — the modal simply
+                had no mount point on this branch. */}
+            {focusedEditing === optionName ?
+              <FocusedEditing
+                isFullscreen
+                modalOnly
+                onClose={() => setFocusedEditing(undefined)}
+                description={(schema?.display_name as string) || optionName}
+              >
+                <Description
+                  longDescription={schema?.desc}
+                  shortDescription={schema?.short_desc}
+                  longDescriptionShownByDefault
+                />
+                {renderOption(optionName, optionField)}
+              </FocusedEditing>
+            : null}
           </StyledColumn>
         );
       }
@@ -1122,24 +1169,7 @@ export const CompactRow = memo(
               {required ?
                 <ReqoreIcon icon='Asterisk' color='danger' size='10px' margin='left' marginSize='tiny' />
               : null}
-              {schema?.desc ?
-                <ReqoreIcon
-                  icon='QuestionLine'
-                  size='12px'
-                  effect={{ opacity: 0.55 }}
-                  margin='left'
-                  marginSize='tiny'
-                  role='button'
-                  tabIndex={-1}
-                  aria-label='Help'
-                  className='options-readfirst-help'
-                  style={{ cursor: 'help' }}
-                  onClick={(event) => {
-                    event.stopPropagation();
-                    handleOptionLabelClick(optionName);
-                  }}
-                />
-              : null}
+              {helpIcon}
             </span>
             {typeLabel ?
               <ReqoreTag size='tiny' minimal label={typeLabel} labelEffect={{ opacity: 0.55 }} />

--- a/src/components/form/engine/FormEngine.stories.tsx
+++ b/src/components/form/engine/FormEngine.stories.tsx
@@ -1680,6 +1680,87 @@ export const Compact: Story = {
   },
 };
 
+// `name` gains a long-form `desc` so the `?` help affordance has something to
+// open — the rest of the compact fixture is unchanged.
+const CompactHelpSchema: Record<string, TCompactField> = {
+  ...CompactSchema,
+  name: {
+    ...CompactSchema.name,
+    desc: 'The unique identifier for this interface. It is used in URLs, logs and cross-references, so it cannot be changed once the interface is deployed.',
+  },
+};
+
+export const CompactFocusedEditingInline: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders the compact form, opens the Name row for inline editing and picks "Edit fullscreen" from its More menu — the Focused Editing modal opens over that single scalar field with its long description above the editor.',
+      },
+    },
+    chromatic: { disable: true },
+  },
+  args: {
+    ...Compact.args,
+    options: CompactHelpSchema,
+  },
+  play: async () => {
+    // Name is a scalar, so it edits INLINE in the row (no expanded card) — the
+    // branch whose More menu used to set the focused state with nothing mounted
+    // to render the modal. (CompactFocusedEditing covers the card branch.)
+    await _testsClickText('order-fulfilment');
+    await _testsWaitForInputValue('order-fulfilment', '.options-readfirst-inline .reqore-textarea');
+    await _testsClickButton({ selector: '.options-readfirst-more' });
+    let fsItem: Element | undefined;
+    await waitFor(
+      () => {
+        fsItem = Array.from(document.querySelectorAll('.reqore-menu-item')).find((element) =>
+          element.textContent?.includes('Edit fullscreen')
+        );
+        expect(fsItem).toBeTruthy();
+      },
+      { timeout: 10000 }
+    );
+    await fireEvent.click(fsItem as Element);
+    // The modal mounts, carrying the field's long description with it.
+    await waitFor(() => expect(document.querySelector('.reqore-modal')).toBeTruthy(), {
+      timeout: 10000,
+    });
+    await _testsWaitForText(/unique identifier for this interface/i);
+  },
+};
+
+export const CompactEditingShowsDescription: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Renders the compact form with the descriptions toggle off — a collapsed row hides its short description, and opening the row for editing reveals it under the field name along with the `?` help affordance.",
+      },
+    },
+  },
+  args: {
+    ...Compact.args,
+    options: CompactHelpSchema,
+  },
+  play: async () => {
+    // Collapsed: the global descriptions toggle is off, so no short_desc on the
+    // read row (the label carries it as a title attribute only).
+    await _testsWaitForText('order-fulfilment');
+    await _testsWaitForTextToNotExist('Unique identifier for this interface');
+    // Open it: the short description appears without the user clicking anything…
+    await _testsClickText('order-fulfilment');
+    await _testsWaitForInputValue('order-fulfilment', '.options-readfirst-inline .reqore-textarea');
+    await _testsWaitForText('Unique identifier for this interface');
+    // …and the `?` (long-form help) stays reachable while editing.
+    await waitFor(() =>
+      expect(
+        document.querySelector('.options-readfirst-inline .options-readfirst-help')
+      ).toBeTruthy()
+    );
+  },
+};
+
 export const CompactWithPanelProps: Story = {
   parameters: {
     docs: {


### PR DESCRIPTION
Two fixes to the compact (read-first) form's editing state. Follows [#80](https://github.com/qoretechnologies/toolkit-react/pull/80).

## 1. "Edit fullscreen" did nothing on a scalar field

The compact row has two expanded layouts. The **card** (complex fields) wraps its editor in `<FocusedEditing>`; the **inline** row (string / number / bool / …) renders its editor straight into the row grid. Both offer "Edit fullscreen" in the More menu — so on an inline row the click set `focusedEditing` and nothing rendered it. **The modal had no mount point on that branch.**

That is also why the existing `CompactFocusedEditing` story never caught it: it drives `tags`, a list, which is a card.

`FocusedEditing` renders its children **twice** when open (in place *and* in the modal), which is what the card and classic layouts rely on. An inline row already renders its editor, so instead of hand-rolling a second modal it gains **`modalOnly`** — render the overlay alone — and the inline branch mounts it.

## 2. Opening a field hid its description

The `?` help affordance lived only on read rows, and `short_desc` under the label was gated behind the global descriptions toggle. Opening a field therefore left it with **no route to its own documentation at all**.

- An **open** field now always shows its `short_desc` — that's where the hint is needed and there's no per-row button to reveal it. This also matches what the edit card already did.
- The global toggle keeps governing **read** rows, so collapsing the field hides it again.
- The `?` is extracted into one `helpIcon` shared by the read row and the inline editor, rather than living only on the former.

## Testing

Two new stories:

- `Form/Engine/FormEngine · CompactFocusedEditingInline` — opens Name (scalar → inline), More → Edit fullscreen, asserts the modal mounts with the field's long description. This is the branch that was broken.
- `Form/Engine/FormEngine · CompactEditingShowsDescription` — with the toggle off: collapsed row hides the short description, opening it reveals the description **and** the `?`.

Local Qlip captures of both read and verified before commit (deleted afterwards). `yarn test` 478 passed; `build:test:prod` and `lint` clean. The story files bound to this code pass except `Option With Any Type`, `Toggle In Form Engine` and `Via Form Engine Ui Type`, which need a live Qorus instance (`REACT_APP_QORUS_TOKEN`, supplied in CI by secrets) — they were green in CI on #80.

Version bumped `0.10.14` → `0.10.15`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)