### PR TITLE
feat(form-engine): let a caller name the read-first rows to open on mount

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
   "devDependencies": {
     "@chromatic-com/storybook": "^5.2.1",
     "@netsells/storybook-mockdate": "^0.3.3",
-    "@qoretechnologies/qlip": "^0.1.3-beta.20260622084321",
+    "@qoretechnologies/qlip": "^0.1.3-beta.20260724071501",
     "@qoretechnologies/reqore": "^0.71.6",
     "@storybook/addon-docs": "^10.4.6",
     "@storybook/addon-links": "^10.4.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qoretechnologies/reqraft",
-  "version": "0.10.15",
+  "version": "0.10.16",
   "description": "ReQraft is a collection of React components and hooks that are used across Qore Technologies' products made using the ReQore component library from Qore.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/components/form/engine/FormEngine.stories.tsx
+++ b/src/components/form/engine/FormEngine.stories.tsx
@@ -5162,6 +5162,79 @@ export const CompactAutoFocusFirstRequired: Story = {
   },
 };
 
+// `initialExpandedOptions` opens rows the CALLER names, for the case where the
+// expanded row is part of an address rather than a click: a field that renders
+// its own routable surface can restore the pane from the URL, but not the row
+// that has to be open for the pane to exist. Here `description` starts expanded
+// with no interaction, while a row the caller did not name stays collapsed.
+export const CompactInitialExpandedOptions: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders a compact form with initialExpandedOptions — the caller-named row is already open on mount, and rows it did not name stay collapsed.',
+      },
+    },
+  },
+  args: {
+    compact: true,
+    minColumnWidth: '300px',
+    options: CompactSchema,
+    value: CompactValue,
+    groups: CompactGroups,
+    initialExpandedOptions: ['description'],
+  },
+  play: async () => {
+    await _testsWaitForText('order-fulfilment');
+
+    // The caller-named row is open on mount, with no click.
+    await waitFor(
+      () =>
+        expect(
+          document.querySelector(
+            '[data-field="description"] input, [data-field="description"] textarea'
+          )
+        ).toBeTruthy(),
+      { timeout: 10000 }
+    );
+
+    // A row the caller did not name is NOT expanded.
+    expect(
+      document.querySelector('[data-field="name"] input, [data-field="name"] textarea')
+    ).toBeFalsy();
+  },
+};
+
+// An unknown name must not throw or expand anything — a stale link naming a
+// field this schema no longer has just lands on the collapsed form.
+export const CompactInitialExpandedOptionsUnknownName: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders a compact form whose initialExpandedOptions names a field that does not exist — the form renders normally with every row collapsed.',
+      },
+    },
+  },
+  args: {
+    compact: true,
+    minColumnWidth: '300px',
+    options: CompactSchema,
+    value: CompactValue,
+    groups: CompactGroups,
+    initialExpandedOptions: ['no-such-field'],
+  },
+  play: async () => {
+    await _testsWaitForText('order-fulfilment');
+    await sleep(300);
+    expect(
+      document.querySelector(
+        '[data-field="description"] input, [data-field="description"] textarea'
+      )
+    ).toBeFalsy();
+  },
+};
+
 // A required field can be FILLED yet INVALID — here `endpoint` has a value that
 // fails its own `validation_regex` (it must be an http(s) URL). It still "needs
 // attention", so autofocus must land on IT and not skip ahead to the empty

--- a/src/components/form/engine/FormEngine.tsx
+++ b/src/components/form/engine/FormEngine.tsx
@@ -586,6 +586,27 @@ export interface IFormEngineProps extends Omit<IReqoreCollectionProps, 'onChange
    * classic (non-compact) mode. Default: off.
    */
   autoFocusFirstRequired?: boolean;
+
+  /**
+   * Names of read-first rows to open on mount, in addition to whatever the
+   * user opens afterwards.
+   *
+   * Which rows are expanded is otherwise private to the engine, which is
+   * fine while expansion is only ever a click. It stops being fine when the
+   * expanded row is part of an address: a consumer whose field renders its
+   * own routable surface (a table whose rows open panes with their own URLs)
+   * can restore the pane from the URL, but not the row that has to be open
+   * for the pane to exist at all — so a pasted or reloaded link lands on a
+   * collapsed form.
+   *
+   * Applied once, on the first render where the schema has rows, so an
+   * async-loaded schema is covered. It never re-expands a row the user has
+   * since collapsed, and it does not participate in `expandMode: 'single'`
+   * accordion collapsing — the caller is naming a starting point, not
+   * driving the state. Only a remount re-arms it. No-op in classic
+   * (non-compact) mode.
+   */
+  initialExpandedOptions?: string[];
 }
 
 // Option types rendered full-width (IDE Options parity, commit 8e6b7781).
@@ -626,6 +647,7 @@ export const FormEngine = ({
   componentOverrides,
   inheritedFromParent,
   autoFocusFirstRequired,
+  initialExpandedOptions,
   ...rest
 }: IFormEngineProps) => {
   const [options, setOptions] = useState<IQorusFormSchema | undefined>(rest?.options || undefined);
@@ -1540,6 +1562,32 @@ export const FormEngine = ({
     },
     [expandMode]
   );
+
+  // --- Caller-named starting rows (opt-in) ----------------------------------
+  // `initialExpandedOptions` lets a consumer name the rows that must already
+  // be open when the form first paints — the case where the expanded row is
+  // part of an address rather than a click (see the prop's docs).
+  //
+  // One-shot for the same reason autofocus is: it fires on the first render
+  // that actually has rows (so an async-loaded schema is covered) and then
+  // never again, so a row the user collapses afterwards stays collapsed and a
+  // later schema reload does not reopen it.
+  const hasAppliedInitialExpansionRef = useRef(false);
+  useEffect(() => {
+    if (!initialExpandedOptions?.length || !compact || hasAppliedInitialExpansionRef.current) {
+      return;
+    }
+    const names = Object.keys(availableOptions);
+    if (!names.length) {
+      return;
+    }
+    hasAppliedInitialExpansionRef.current = true;
+    const toExpand = initialExpandedOptions.filter((name) => names.includes(name));
+    if (!toExpand.length) {
+      return;
+    }
+    setExpandedOptions((prev) => [...prev, ...toExpand.filter((name) => !prev.includes(name))]);
+  }, [initialExpandedOptions, compact, availableOptions]);
 
   // --- First-attention-field autofocus (opt-in) -----------------------------
   // With `autoFocusFirstRequired`, drop the user straight into the first field

--- a/yarn.lock
+++ b/yarn.lock
@@ -1379,10 +1379,10 @@
   resolved "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz"
   integrity sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==
 
-"@qoretechnologies/qlip@^0.1.3-beta.20260622084321":
-  version "0.1.3-beta.20260622084321"
-  resolved "https://registry.yarnpkg.com/@qoretechnologies/qlip/-/qlip-0.1.3-beta.20260622084321.tgz#4e66b90e6eb84692795f28ad0469d9caeb58ed94"
-  integrity sha512-HGjwZKsIdx00GTg+drTsWWXtY6EX9u8E3HuFxW+KYH1vG2jsTfZwlpCJ2m7tB5AW72Nbt/A8aNjJ14Hph03LiQ==
+"@qoretechnologies/qlip@^0.1.3-beta.20260724071501":
+  version "0.1.3-beta.20260724071501"
+  resolved "https://registry.yarnpkg.com/@qoretechnologies/qlip/-/qlip-0.1.3-beta.20260724071501.tgz#19117eb1737581f3acddc0bc5bda2c7c7dcf1738"
+  integrity sha512-SGRDzB1ayO27FvlrJIsUR57ATHntnBDyuW7HaFJ0eTzwLfS9GQwBOich8qA+55gIg6wtrYVKlhq1At89pdQVKA==
 
 "@qoretechnologies/reqore@^0.71.6":
   version "0.71.6"


### PR DESCRIPTION
Closes #82

## Why

Which read-first rows are expanded is private to `FormEngine`. That is fine while expansion is only ever a click — it stops being fine when the expanded row is **part of an address**.

A field can render its own routable surface: a table whose rows open panes with their own URLs. Such a consumer can restore the pane from the URL, but not the row that has to be open for the pane to exist at all — so a pasted or reloaded link lands on a collapsed form and the pane the link names is simply not there.

Concretely: the Qorus IDE's test editor renders `cases` as a table whose rows open case / setup-step / assertion panes, each URL-addressable. Clicking a case put the pane in the URL correctly; pasting that URL back showed a collapsed row and no pane.

## What

`initialExpandedOptions?: string[]` — the rows to open on mount.

- applied **once**, on the first render where the schema has rows, so an async-loaded schema is covered
- never re-expands a row the user has since collapsed
- does **not** take part in `expandMode: 'single'` accordion collapsing — the caller names a starting point, it does not drive the state
- unknown names ignored, so a stale link renders the normal form
- no-op in classic (non-compact) mode

It deliberately mirrors the one-shot ref discipline of the adjacent `autoFocusFirstRequired` effect rather than introducing a second mechanism, and reuses the same `setExpandedOptions` seam.

## Tests

Two stories, both passing:

- `CompactInitialExpandedOptions` — the caller-named row is open on mount with no interaction, and a row the caller did not name stays collapsed
- `CompactInitialExpandedOptionsUnknownName` — an unknown name neither throws nor expands anything

Verified end-to-end against the real consumer: built this branch, linked the dist into qorus-ide, and loaded a cold editor URL naming a case, phase and step — the whole pane stack restores with zero clicks; a stale case name renders the normal form.

## Checks

- `eslint src/components/form/engine/*` — clean
- `vitest --project unit` — **478 passed**
- `tsc --project tsconfig.prod.json --noEmit` — clean
- `vitest --project storybook FormEngine.stories.tsx` — 82 passed, 1 failed **locally only** (see below)
- version bumped `0.10.15` → `0.10.16`
- CI `PullRequestTests` — green, including the Storybook interaction tests

### Note on the one story that fails locally

`Option With Any Type` fails on my machine, and it is **not caused by this PR**: reverting both changed files to `origin/develop` content reproduces the identical failure (`toBeInTheDocument()` received `undefined`), consistently rather than flakily. It is defined ~4600 lines before these additions and does not use the new prop.

CI runs the same Storybook interaction tests and passes them, so this is a local-environment difference, not a defect on `develop` — flagging it only so a reviewer who hits it locally knows it is not from this change.
