### PR TITLE
fix(form-engine): preserve renderer option values

### DIFF
--- a/__tests__/formEngineOptions.test.ts
+++ b/__tests__/formEngineOptions.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from 'vitest';
+import {
+  fixOptions,
+  getType,
+  getTypeAndCanBeNull,
+} from '../src/components/form/engine/FormEngine';
+
+describe('FormEngine option type resolution', () => {
+  it('uses an untyped renderer while server-driven schema metadata is unavailable', () => {
+    expect(getType(undefined)).toBe('any');
+    expect(getType([])).toBe('any');
+    expect(getTypeAndCanBeNull(undefined)).toEqual({
+      type: 'any',
+      defaultType: 'any',
+      defaultInternalType: undefined,
+      canBeNull: false,
+    });
+  });
+
+  it('continues to normalize nullable generic types', () => {
+    expect(getTypeAndCanBeNull('soft*hash<string, int>' as never)).toEqual({
+      type: 'hash',
+      defaultType: 'hash',
+      defaultInternalType: 'hash',
+      canBeNull: true,
+    });
+  });
+});
+
+describe('fixOptions', () => {
+  it('preserves persisted values until their server-driven schema arrives', () => {
+    const value = { payload: { value: 'Calendar attachment' } } as never;
+
+    expect(fixOptions(value, undefined)).toEqual(value);
+    expect(fixOptions(value, {})).toEqual(value);
+  });
+
+  it('adds the schema type without nesting an untyped form field value', () => {
+    expect(
+      fixOptions(
+        { payload: { value: 'Calendar attachment', op: ['trim'] } } as never,
+        { payload: { type: 'string', ui_type: 'string' } } as never
+      )
+    ).toEqual({
+      payload: { type: 'string', value: 'Calendar attachment', op: ['trim'] },
+    });
+  });
+
+  it('keeps every key the untyped envelope carried', () => {
+    // Rebuilding the field from just {type, value} dropped these and emptied the
+    // rendered card — the file option lost its content on revert.
+    const fixed = fixOptions(
+      {
+        fileOption: {
+          value: { name: 'file.txt', size: 1234 },
+          is_expression: true,
+          op: ['trim'],
+          some_renderer_hint: 'keep-me',
+        },
+      } as never,
+      { fileOption: { type: 'file', ui_type: 'file' } } as never
+    );
+
+    expect(fixed.fileOption).toEqual({
+      type: 'file',
+      value: { name: 'file.txt', size: 1234 },
+      is_expression: true,
+      op: ['trim'],
+      some_renderer_hint: 'keep-me',
+    });
+  });
+
+  it('stores a renderer-only ui_type under the schema type, not the renderer name', () => {
+    // `cron` names an editor; the value is still stored as the schema's string.
+    const fixed = fixOptions(
+      { schedule: { value: '0 0 * * *' } } as never,
+      { schedule: { type: 'string', ui_type: 'cron' } } as never
+    );
+
+    expect(fixed.schedule).toEqual({ type: 'string', value: '0 0 * * *' });
+  });
+
+  it('lets a storage-compatible ui_type win over the schema type', () => {
+    const fixed = fixOptions(
+      { note: { value: 'hello' } } as never,
+      { note: { type: 'string', ui_type: 'long-string' } } as never
+    );
+
+    expect(fixed.note).toEqual({ type: 'long-string', value: 'hello' });
+  });
+});

--- a/__tests__/optionActions.test.ts
+++ b/__tests__/optionActions.test.ts
@@ -1,0 +1,96 @@
+import { IReqorePanelAction } from '@qoretechnologies/reqore/dist/components/Panel';
+import { describe, expect, it, vi } from 'vitest';
+import {
+  IOptionActionsContext,
+  resolveOptionActions,
+} from '../src/components/form/engine/optionActions';
+import {
+  BUILT_IN_RENDERER_ONLY_UI_TYPES,
+  createRendererOnlyUiTypeCheck,
+  isRendererOnlyUiType,
+} from '../src/components/form/engine/rendererTypes';
+
+const context: IOptionActionsContext = {
+  name: 'my_option',
+  schema: { type: 'string', display_name: 'My option' } as IOptionActionsContext['schema'],
+  value: { type: 'string', value: 'hello' },
+};
+
+describe('resolveOptionActions', () => {
+  it('returns an empty list when no actions were injected', () => {
+    expect(resolveOptionActions(undefined, context)).toEqual([]);
+  });
+
+  it('passes a static list through unchanged', () => {
+    const actions: IReqorePanelAction[] = [{ icon: 'MagicLine' }, { icon: 'InformationLine' }];
+
+    expect(resolveOptionActions(actions, context)).toEqual(actions);
+  });
+
+  it('calls a factory with the option context', () => {
+    const factory = vi.fn(() => [{ icon: 'MagicLine' } as IReqorePanelAction]);
+
+    const result = resolveOptionActions(factory, context);
+
+    expect(factory).toHaveBeenCalledTimes(1);
+    expect(factory).toHaveBeenCalledWith(context);
+    expect(result).toEqual([{ icon: 'MagicLine' }]);
+  });
+
+  it('drops falsy entries so a factory can return conditional actions inline', () => {
+    const factory = () =>
+      [
+        { icon: 'MagicLine' },
+        false && { icon: 'DeleteBinLine' },
+        undefined,
+        null,
+        { icon: 'InformationLine' },
+      ] as IReqorePanelAction[];
+
+    expect(resolveOptionActions(factory, context)).toEqual([
+      { icon: 'MagicLine' },
+      { icon: 'InformationLine' },
+    ]);
+  });
+
+  it('survives a factory that returns nothing', () => {
+    expect(resolveOptionActions((() => undefined) as never, context)).toEqual([]);
+  });
+});
+
+describe('createRendererOnlyUiTypeCheck', () => {
+  it('recognises reqraft built-in renderer-only ui types', () => {
+    expect(isRendererOnlyUiType('cron')).toBe(true);
+    expect(isRendererOnlyUiType('processor-mappings')).toBe(true);
+    expect(BUILT_IN_RENDERER_ONLY_UI_TYPES).toContain('code-editor');
+  });
+
+  it('does not treat storage types as renderer-only', () => {
+    expect(isRendererOnlyUiType('string')).toBe(false);
+    expect(isRendererOnlyUiType('hash')).toBe(false);
+    expect(isRendererOnlyUiType('long-string')).toBe(false);
+  });
+
+  it('ignores non-string types (an array ui_type names no single renderer)', () => {
+    expect(isRendererOnlyUiType(undefined)).toBe(false);
+    expect(isRendererOnlyUiType(['cron', 'string'] as never)).toBe(false);
+  });
+
+  it('recognises a consumer-declared renderer type without a reqraft release', () => {
+    const check = createRendererOnlyUiTypeCheck(['my-custom-editor']);
+
+    expect(check('my-custom-editor')).toBe(true);
+    // built-ins still apply alongside the consumer's own
+    expect(check('cron')).toBe(true);
+    expect(check('string')).toBe(false);
+  });
+
+  it('keeps each instance independent — one consumer cannot leak into another', () => {
+    const withExtra = createRendererOnlyUiTypeCheck(['my-custom-editor']);
+    const withoutExtra = createRendererOnlyUiTypeCheck();
+
+    expect(withExtra('my-custom-editor')).toBe(true);
+    expect(withoutExtra('my-custom-editor')).toBe(false);
+    expect(isRendererOnlyUiType('my-custom-editor')).toBe(false);
+  });
+});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qoretechnologies/reqraft",
-  "version": "0.10.16",
+  "version": "0.10.17",
   "description": "ReQraft is a collection of React components and hooks that are used across Qore Technologies' products made using the ReQore component library from Qore.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/components/form/engine/CompactRow.tsx
+++ b/src/components/form/engine/CompactRow.tsx
@@ -109,6 +109,12 @@ const COMPACT_SINGLE_VALUE_TYPES = new Set([
   'method-name',
 ]);
 
+// How many consumer-injected actions may sit inline in a row before the rest
+// overflow into the row's menu. A row's action slot shares space with the
+// value; an unbounded button strip would squeeze the value out, and the
+// consumer controls how many actions it injects.
+const MAX_INLINE_OPTION_ACTIONS = 2;
+
 
 // One read-first row: label | value | action collapsed; the real editor (the
 // classic renderOption) expanded. `hidden` = search-surfaced optional —
@@ -179,6 +185,10 @@ export const CompactRow = memo(
     const getTypeForOption = useContextSelector(CompactRowContext, (v) => v.getTypeForOption);
     const confirmAction = useContextSelector(CompactRowContext, (v) => v.confirmAction);
     const optionActions = useContextSelector(CompactRowContext, (v) => v.optionActions);
+    const collapseOptionActions = useContextSelector(
+      CompactRowContext,
+      (v) => v.collapseOptionActions
+    );
     const renderOption = useContextSelector(CompactRowContext, (v) => v.renderOption);
     const theme = useContextSelector(CompactRowContext, (v) => v.theme);
     const cMuted = useContextSelector(CompactRowContext, (v) => v.cMuted);
@@ -351,6 +361,40 @@ export const CompactRow = memo(
           }).filter((action) => action.show !== false)
         : [],
       [availableOptions?.[optionName], optionActions, optionName, schema]
+    );
+    // Which injected actions stay as inline buttons, and which move into the
+    // overflow menu. Everything collapses on touch / narrow viewports — a
+    // hover-gated button is unreachable without a hover — and anything past the
+    // inline cap overflows regardless, so a consumer injecting ten actions can
+    // never push the row's value out of view.
+    const [inlineOptionActions, menuOptionActions] = React.useMemo<
+      [IReqorePanelAction[], IReqorePanelAction[]]
+    >(
+      () =>
+        collapseOptionActions ?
+          [[], injectedOptionActions]
+        : [
+            injectedOptionActions.slice(0, MAX_INLINE_OPTION_ACTIONS),
+            injectedOptionActions.slice(MAX_INLINE_OPTION_ACTIONS),
+          ],
+      [collapseOptionActions, injectedOptionActions]
+    );
+    const injectedOptionActionMenuItems = React.useMemo<IReqoreDropdownItem[]>(
+      () =>
+        menuOptionActions.map(
+          (action, index) =>
+            ({
+              // A panel action labels itself with `label`, but an icon-only one
+              // (the IDE's AI-assist button) carries its name in the tooltip —
+              // a menu row has no hover affordance to fall back on.
+              label: action.label ?? action.tooltip ?? `Action ${index + 1}`,
+              icon: action.icon,
+              intent: action.intent,
+              disabled: action.disabled,
+              onClick: () => action.onClick?.(),
+            }) as IReqoreDropdownItem
+        ),
+      [menuOptionActions]
     );
     const renderInjectedOptionAction = (
       action: IReqorePanelAction,
@@ -728,6 +772,10 @@ export const CompactRow = memo(
               } as IReqoreDropdownItem,
             ]
           : []),
+          // Consumer-injected actions that did not fit inline (or collapsed
+          // wholesale on touch) land here — this row already has a menu, so they
+          // reuse it rather than adding a second one beside it.
+          ...injectedOptionActionMenuItems,
         ]}
       />
     );
@@ -801,7 +849,7 @@ export const CompactRow = memo(
                   message strip is visible. */}
               {revertButton}
               {clearValueButton}
-              {injectedOptionActions.map((action, index) =>
+              {inlineOptionActions.map((action, index) =>
                 renderInjectedOptionAction(action, index)
               )}
               {moreMenu}
@@ -958,7 +1006,7 @@ export const CompactRow = memo(
                   </ReqoreButton>
                 );
               })}
-              {injectedOptionActions.map((action, index) =>
+              {inlineOptionActions.map((action, index) =>
                 renderInjectedOptionAction(action, index)
               )}
               {/* Clear-value sits before the More menu — the card analog of the
@@ -1363,9 +1411,31 @@ export const CompactRow = memo(
               {infoToggle}
             </StyledActionSlot>
           : null}
-          {injectedOptionActions.map((action, index) =>
+          {inlineOptionActions.map((action, index) =>
             renderInjectedOptionAction(action, index, 'tiny')
           )}
+          {injectedOptionActionMenuItems.length ?
+            <StyledActionSlot
+              className='options-readfirst-actions-slot'
+              $width={26}
+              // The read row opens the editor when clicked. Without this the tap
+              // that opens this menu also expands the row, which unmounts the
+              // menu — on touch that made the collapsed actions unreachable,
+              // the exact problem the collapse exists to solve.
+              onClick={(event: React.MouseEvent<HTMLElement>) => event.stopPropagation()}
+            >
+              <ReqoreDropdown
+                className='options-injected-actions-menu'
+                icon='MoreFill'
+                flat
+                minimal
+                fixed
+                size='tiny'
+                tooltip='Field actions'
+                items={injectedOptionActionMenuItems}
+              />
+            </StyledActionSlot>
+          : null}
           {/* The revert affordance lives in the status-dot column (a changed field
               swaps its dot for the revert icon) so it sits at the same fixed x as
               the dot — out of the value's way instead of floating over it. */}

--- a/src/components/form/engine/CompactRow.tsx
+++ b/src/components/form/engine/CompactRow.tsx
@@ -406,11 +406,18 @@ export const CompactRow = memo(
       // the compact slots render plain buttons, so 'hover' becomes a CSS gate on
       // the containing row/card (see compactRowStyles) — same config, same
       // behaviour in both modes.
+      // `size` is destructured out and deliberately NOT honoured: the row owns
+      // its action strip's rhythm, and a consumer-supplied size made the
+      // injected button visibly smaller than the revert / more / confirm
+      // buttons beside it. The contextual `size` argument is the row's own
+      // (small when editing or in a card, tiny on a read row), so injected
+      // actions always match their neighbours.
       const {
         label: actionLabel,
         onClick,
         show,
-        size: actionSize,
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        size: _ignoredSize,
         className,
         ...actionProps
       } = action;
@@ -418,7 +425,7 @@ export const CompactRow = memo(
       return (
         <ReqoreButton
           key={`${optionName}-injected-action-${index}`}
-          size={actionSize || size}
+          size={size}
           minimal
           flat
           fixed

--- a/src/components/form/engine/CompactRow.tsx
+++ b/src/components/form/engine/CompactRow.tsx
@@ -11,6 +11,7 @@ import {
 } from '@qoretechnologies/reqore';
 import { IReqoreDropdownItem } from '@qoretechnologies/reqore/dist/components/Dropdown/list';
 import { IReqorePanelAction } from '@qoretechnologies/reqore/dist/components/Panel';
+import { resolveOptionActions } from './optionActions';
 import {
   IQorusFormField,
   TQorusForm,
@@ -340,28 +341,35 @@ export const CompactRow = memo(
 
     const schema = options?.[optionName];
     const label = schema?.display_name || optionName;
-    const injectedOptionActions = React.useMemo<IReqorePanelAction[]>(() => {
-      if (!schema) {
-        return [];
-      }
-
-      const actions =
-        typeof optionActions === 'function'
-          ? optionActions({
-              name: optionName,
-              schema,
-              value: availableOptions?.[optionName],
-            })
-          : (optionActions ?? []);
-
-      return actions.filter((action) => !!action && action.show !== false);
-    }, [availableOptions, optionActions, optionName, schema]);
+    const injectedOptionActions = React.useMemo<IReqorePanelAction[]>(
+      () =>
+        schema ?
+          resolveOptionActions(optionActions, {
+            name: optionName,
+            schema,
+            value: availableOptions?.[optionName],
+          }).filter((action) => action.show !== false)
+        : [],
+      [availableOptions?.[optionName], optionActions, optionName, schema]
+    );
     const renderInjectedOptionAction = (
       action: IReqorePanelAction,
       index: number,
       size: 'tiny' | 'small' = 'small'
     ) => {
-      const { label: actionLabel, onClick, show: _show, size: actionSize, ...actionProps } = action;
+      // `show` drives visibility here instead of reaching the DOM. The classic
+      // path hands these to ReqorePanel, which honours `show: 'hover'` itself;
+      // the compact slots render plain buttons, so 'hover' becomes a CSS gate on
+      // the containing row/card (see compactRowStyles) — same config, same
+      // behaviour in both modes.
+      const {
+        label: actionLabel,
+        onClick,
+        show,
+        size: actionSize,
+        className,
+        ...actionProps
+      } = action;
 
       return (
         <ReqoreButton
@@ -371,6 +379,9 @@ export const CompactRow = memo(
           flat
           fixed
           {...actionProps}
+          className={`${className ? `${className} ` : ''}options-injected-action${
+            show === 'hover' ? ' options-injected-action-hover' : ''
+          }`}
           onClick={(event: React.MouseEvent<HTMLElement>) => {
             event.stopPropagation();
             onClick?.();

--- a/src/components/form/engine/CompactRow.tsx
+++ b/src/components/form/engine/CompactRow.tsx
@@ -10,6 +10,7 @@ import {
   ReqoreTagGroup,
 } from '@qoretechnologies/reqore';
 import { IReqoreDropdownItem } from '@qoretechnologies/reqore/dist/components/Dropdown/list';
+import { IReqorePanelAction } from '@qoretechnologies/reqore/dist/components/Panel';
 import {
   IQorusFormField,
   TQorusForm,
@@ -176,6 +177,7 @@ export const CompactRow = memo(
     );
     const getTypeForOption = useContextSelector(CompactRowContext, (v) => v.getTypeForOption);
     const confirmAction = useContextSelector(CompactRowContext, (v) => v.confirmAction);
+    const optionActions = useContextSelector(CompactRowContext, (v) => v.optionActions);
     const renderOption = useContextSelector(CompactRowContext, (v) => v.renderOption);
     const theme = useContextSelector(CompactRowContext, (v) => v.theme);
     const cMuted = useContextSelector(CompactRowContext, (v) => v.cMuted);
@@ -338,6 +340,46 @@ export const CompactRow = memo(
 
     const schema = options?.[optionName];
     const label = schema?.display_name || optionName;
+    const injectedOptionActions = React.useMemo<IReqorePanelAction[]>(() => {
+      if (!schema) {
+        return [];
+      }
+
+      const actions =
+        typeof optionActions === 'function'
+          ? optionActions({
+              name: optionName,
+              schema,
+              value: availableOptions?.[optionName],
+            })
+          : (optionActions ?? []);
+
+      return actions.filter((action) => !!action && action.show !== false);
+    }, [availableOptions, optionActions, optionName, schema]);
+    const renderInjectedOptionAction = (
+      action: IReqorePanelAction,
+      index: number,
+      size: 'tiny' | 'small' = 'small'
+    ) => {
+      const { label: actionLabel, onClick, show: _show, size: actionSize, ...actionProps } = action;
+
+      return (
+        <ReqoreButton
+          key={`${optionName}-injected-action-${index}`}
+          size={actionSize || size}
+          minimal
+          flat
+          fixed
+          {...actionProps}
+          onClick={(event: React.MouseEvent<HTMLElement>) => {
+            event.stopPropagation();
+            onClick?.();
+          }}
+        >
+          {actionLabel}
+        </ReqoreButton>
+      );
+    };
     const required = !!(schema?.required || schema?.required_groups);
     const removable =
       !readOnly && !schema?.preselected && !schema?.required && !schema?.required_groups;
@@ -748,6 +790,9 @@ export const CompactRow = memo(
                   message strip is visible. */}
               {revertButton}
               {clearValueButton}
+              {injectedOptionActions.map((action, index) =>
+                renderInjectedOptionAction(action, index)
+              )}
               {moreMenu}
               <ReqoreButton
                 className='options-readfirst-done'
@@ -902,6 +947,9 @@ export const CompactRow = memo(
                   </ReqoreButton>
                 );
               })}
+              {injectedOptionActions.map((action, index) =>
+                renderInjectedOptionAction(action, index)
+              )}
               {/* Clear-value sits before the More menu — the card analog of the
                   inline row's Clear. Empties the value (keeps the field). */}
               {hasValue && !readOnly ?
@@ -1304,6 +1352,9 @@ export const CompactRow = memo(
               {infoToggle}
             </StyledActionSlot>
           : null}
+          {injectedOptionActions.map((action, index) =>
+            renderInjectedOptionAction(action, index, 'tiny')
+          )}
           {/* The revert affordance lives in the status-dot column (a changed field
               swaps its dot for the revert icon) so it sits at the same fixed x as
               the dot — out of the value's way instead of floating over it. */}

--- a/src/components/form/engine/FormEngine.tsx
+++ b/src/components/form/engine/FormEngine.tsx
@@ -244,12 +244,16 @@ const StyledCommitDock = styled.div<{ $bg: string; $border: string }>`
 `;
 
 export const getType = (
-  type: TQorusType | TQorusType[],
+  type?: TQorusType | TQorusType[],
   operators?: IOperatorsSchema,
   operator?: TOperatorValue
 ): TQorusType => {
   const finalType = getTypeFromOperator(operators, fixOperatorValue(operator)) || type;
-  return (isArray(finalType) ? finalType[0] : finalType) as TQorusType;
+  const resolvedType = isArray(finalType) ? finalType[0] : finalType;
+
+  // A value can be received before its server-driven option schema. Keep the
+  // renderer type-safe during that transition without guessing a concrete type.
+  return (resolvedType || 'any') as TQorusType;
 };
 
 const getTypeFromOperator = (
@@ -309,11 +313,18 @@ export const OptionsContext = createContext<{
 
 export const fixOptions = (
   value: TQorusForm | TQorusFlatForm = {},
-  options: IQorusFormSchema,
+  options?: IQorusFormSchema,
   operators?: IOperatorsSchema,
   isRendererOnly: TRendererOnlyCheck = isRendererOnlyUiType
 ): TQorusForm => {
   const fixedValue = cloneDeep(value);
+
+  // Server-driven schemas can arrive after the persisted value. Preserve that
+  // value verbatim until its schema is available instead of manufacturing
+  // partially typed form fields that can crash the following render.
+  if (!size(options)) {
+    return fixedValue as TQorusForm;
+  }
 
   forEach(options, (option, name) => {
     if (
@@ -363,7 +374,11 @@ export const fixOptions = (
         const isUntypedEnvelope = isPlainObject(newOption) && 'value' in newOption;
         const untypedFieldValue =
           isUntypedEnvelope ? (newOption as IQorusFormField).value : newOption;
+        // Spread the original envelope first so every key it carried survives —
+        // rebuilding from just {type, value} silently dropped `op`, `is_expression`
+        // and anything else a field needs to render, which emptied the card.
         const fixedOption: IQorusFormField = {
+          ...(isPlainObject(newOption) ? (newOption as IQorusFormField) : {}),
           type: getType(
             getOptionSchemaStorageType(options?.[optionName], isRendererOnly),
             operators,
@@ -371,10 +386,6 @@ export const fixOptions = (
           ),
           value: untypedFieldValue,
         };
-
-        if ((newOption as IQorusFormField)?.is_expression) {
-          fixedOption.is_expression = true;
-        }
 
         newOption = fixedOption;
       } else if (
@@ -458,7 +469,7 @@ export const flattenOptions = (options: TQorusForm): TQorusFlatForm => {
 };
 
 export const getTypeAndCanBeNull = (
-  type: TQorusType | TQorusType[],
+  type?: TQorusType | TQorusType[],
   allowed_values?: any[],
   operatorData?: TOperatorValue,
   operators?: IOperatorsSchema
@@ -1845,6 +1856,16 @@ export const FormEngine = ({
       suppressSchemaMessages?: boolean
     ) => {
       const operatorParts = fixOperatorValue(other.op);
+      // The RENDERER type for this row. The schema's `ui_type` wins because it
+      // names the editor, and a renderer-only one never reaches the field's
+      // stored `type` any more; the remaining fallbacks keep the row rendering
+      // when a server-driven schema has not arrived yet (type would be
+      // undefined) rather than crashing on it.
+      const resolvedType =
+        (options?.[optionName]?.ui_type as TQorusType) ||
+        type ||
+        (options?.[optionName]?.type as TQorusType) ||
+        'any';
       return (
         <>
           {(() => {
@@ -1986,15 +2007,15 @@ export const FormEngine = ({
             // (DPQL text mode); opt out per-form via `templateFieldProps`.
             allowTextExpressions
             allowCustomValues={
-              options?.[optionName]?.supports_custom_values !== false && type !== 'any'
+              options?.[optionName]?.supports_custom_values !== false && resolvedType !== 'any'
             }
             templates={templates.value}
             {...getTypeAndCanBeNull(
-              type as TQorusType,
+              (type as TQorusType) || (options?.[optionName]?.type as TQorusType),
               options?.[optionName]?.allowed_values,
               other.op
             )}
-            ui_type={(options?.[optionName]?.ui_type as TQorusType) || type}
+            ui_type={resolvedType}
             name={optionName}
             uniqueName={`${uniqueName ? `${uniqueName}.` : `${name ? `${name}.` : ''}`}${optionName}`}
             onChange={
@@ -2035,7 +2056,7 @@ export const FormEngine = ({
             schema={options || {}}
             allOptions={availableOptions}
             name={optionName}
-            option={{ type, ...other }}
+            option={{ type: resolvedType, ...other }}
             getType={getTypeForOption}
           />
           {operators && size(operators) && size(other.op) ?
@@ -2050,7 +2071,7 @@ export const FormEngine = ({
                     intent='info'
                     label={
                       other.value ?
-                        type === 'richtext' ?
+                        resolvedType === 'richtext' ?
                           richtextToString(other.value)
                         : JSON.stringify(other.value)
                       : ''

--- a/src/components/form/engine/FormEngine.tsx
+++ b/src/components/form/engine/FormEngine.tsx
@@ -267,6 +267,43 @@ export const fixOperatorValue = (operator: TOperatorValue): (string | null | und
   return isArray(operator) ? operator : [operator];
 };
 
+const RENDERER_ONLY_UI_TYPES = new Set([
+  'active-windows',
+  'alert-threshold',
+  'code-editor',
+  'cron',
+  'dpql',
+  'processor-mappings',
+  'schema-definition',
+  'test-cases',
+  'test-value-contract',
+  'tool-catalog',
+]);
+
+const isRendererOnlyUiType = (type?: TQorusType | TQorusType[]): boolean =>
+  typeof type === 'string' && RENDERER_ONLY_UI_TYPES.has(type);
+
+const getOptionSchemaStorageType = (option?: TQorusFormFieldSchema): TQorusType =>
+  ((isRendererOnlyUiType(option?.ui_type)
+    ? option?.type || option?.ui_type
+    : option?.ui_type || option?.type) || 'any') as TQorusType;
+
+const getOptionFieldStorageType = (
+  optionName: string,
+  fieldType: TQorusType | TQorusType[] | undefined,
+  schema?: IQorusFormSchema,
+  operators?: IOperatorsSchema,
+  operatorData?: TOperatorValue
+): TQorusType => {
+  const schemaOption = schema?.[optionName];
+  const storedType =
+    fieldType && !(fieldType === schemaOption?.ui_type && isRendererOnlyUiType(fieldType))
+      ? fieldType
+      : getOptionSchemaStorageType(schemaOption);
+
+  return getType(storedType as TQorusType, operators, operatorData);
+};
+
 export const hasRequiredOptions = (options: IQorusFormSchema = {}) => {
   return !!findKey(options, (option) => option.required);
 };
@@ -292,7 +329,7 @@ export const fixOptions = (
     ) {
       let obj: IQorusFormField;
       const type = getType(
-        (option.ui_type || option.type) as TQorusType,
+        getOptionSchemaStorageType(option),
         operators,
         (fixedValue[name] as IQorusFormField)?.op
       );
@@ -328,13 +365,16 @@ export const fixOptions = (
       let newOption = option as IQorusFormField;
 
       if (!isPlainObject(newOption) || !(newOption as IQorusFormField)?.type) {
+        const isUntypedEnvelope = isPlainObject(newOption) && 'value' in newOption;
+        const untypedFieldValue =
+          isUntypedEnvelope ? (newOption as IQorusFormField).value : newOption;
         const fixedOption: IQorusFormField = {
           type: getType(
-            (options?.[optionName]?.ui_type || options?.[optionName]?.type) as TQorusType,
+            getOptionSchemaStorageType(options?.[optionName]),
             operators,
             (newOption as IQorusFormField)?.op
           ),
-          value: newOption,
+          value: untypedFieldValue,
         };
 
         if ((newOption as IQorusFormField)?.is_expression) {
@@ -342,6 +382,18 @@ export const fixOptions = (
         }
 
         newOption = fixedOption;
+      } else if (
+        newOption.type === options?.[optionName]?.ui_type &&
+        isRendererOnlyUiType(newOption.type)
+      ) {
+        newOption = {
+          ...newOption,
+          type: getType(
+            getOptionSchemaStorageType(options?.[optionName]),
+            operators,
+            newOption.op
+          ),
+        };
       }
 
       if (
@@ -976,14 +1028,16 @@ export const FormEngine = ({
   const handleValueChange = useCallback(
     (optionName: string, val?: any, _type?: string, isFunction?: boolean) => {
       setLocalValue(({ fields = {} }) => {
-        const schemaType = (options?.[optionName]?.ui_type ||
-          options?.[optionName]?.type) as TQorusType;
+        const schemaType = getOptionSchemaStorageType(options?.[optionName]);
         const isAnyLike = schemaType === 'any' || schemaType === 'auto';
         // For any/auto schema types, preserve the user's chosen type stored in the field
         const resolvedSchemaType =
-          isAnyLike && (fields[optionName] as IQorusFormField)?.type ?
-            ((fields[optionName] as IQorusFormField).type as TQorusType)
-          : schemaType || ((fields[optionName] as IQorusFormField)?.type as TQorusType);
+          isAnyLike && (fields[optionName] as IQorusFormField)?.type
+            ? ((fields[optionName] as IQorusFormField).type as TQorusType)
+            : (fields[optionName] as IQorusFormField)?.type === options?.[optionName]?.ui_type &&
+                isRendererOnlyUiType((fields[optionName] as IQorusFormField)?.type)
+              ? schemaType
+              : schemaType || ((fields[optionName] as IQorusFormField)?.type as TQorusType);
         const type =
           _type ||
           getTypeAndCanBeNull(resolvedSchemaType, options?.[optionName]?.allowed_values).type;
@@ -1186,8 +1240,7 @@ export const FormEngine = ({
         optionName as string,
         getDefaultValue(options?.[optionName as string]),
         getTypeAndCanBeNull(
-          (options?.[optionName as string]?.ui_type ||
-            options?.[optionName as string]?.type) as TQorusType,
+          getOptionSchemaStorageType(options?.[optionName as string]),
           options?.[optionName as string]?.allowed_values
         ).type
       );
@@ -1215,8 +1268,15 @@ export const FormEngine = ({
           return newValue;
         }
 
-        const schemaType = getType(
+        const rendererType = getType(
           (options[optionName].ui_type || options[optionName].type) as TQorusType,
+          operators,
+          (option as IQorusFormField)?.op
+        );
+        const storageType = getOptionFieldStorageType(
+          optionName,
+          (option as IQorusFormField)?.type,
+          options,
           operators,
           (option as IQorusFormField)?.op
         );
@@ -1225,23 +1285,15 @@ export const FormEngine = ({
           return {
             ...newValue,
             [optionName]: {
-              type: schemaType,
+              type: storageType || rendererType,
               value: option,
             },
           };
         }
 
-        // any/auto: preserve the user-picked type; otherwise normalize to the
-        // schema type (ui_type wins) so rendering and validation agree.
-        const isAnyLike = schemaType === 'any' || schemaType === 'auto';
-        const effectiveType =
-          isAnyLike && (option as IQorusFormField)?.type ?
-            (option as IQorusFormField).type
-          : schemaType;
-
         return {
           ...newValue,
-          [optionName]: { ...(option as IQorusFormField), type: effectiveType },
+          [optionName]: { ...(option as IQorusFormField), type: storageType || rendererType },
         };
       }, {});
   }, [
@@ -1341,10 +1393,13 @@ export const FormEngine = ({
     const fields: IFormFieldValidityData[] = reduce(
       availableOptions,
       (result, option, optionName) => {
-        const type =
-          (option as IQorusFormField).type ||
-          (options?.[optionName]?.ui_type as TQorusType) ||
-          (options?.[optionName]?.type as TQorusType);
+        const type = getOptionFieldStorageType(
+          optionName,
+          (option as IQorusFormField).type,
+          options,
+          operators,
+          (option as IQorusFormField).op
+        );
         const optionValue = (option as IQorusFormField).value;
 
         const isRequired = options?.[optionName]?.required;
@@ -1388,6 +1443,7 @@ export const FormEngine = ({
   }, [
     JSON.stringify(availableOptions),
     JSON.stringify(options),
+    JSON.stringify(operators),
     JSON.stringify(localValue.fields),
   ]);
 
@@ -1406,8 +1462,13 @@ export const FormEngine = ({
           showInvalidOptionsOnly &&
           isOptionValid(
             optionName,
-            (options?.[optionName]?.ui_type as TQorusType) ||
-              (options?.[optionName]?.type as TQorusType),
+            getOptionFieldStorageType(
+              optionName,
+              (option as IQorusFormField).type,
+              options,
+              operators,
+              (option as IQorusFormField).op
+            ),
             (option as IQorusFormField).value
           )
         ) {
@@ -1417,7 +1478,7 @@ export const FormEngine = ({
       },
       {}
     );
-  }, [showInvalidOptionsOnly, JSON.stringify(availableOptions)]);
+  }, [showInvalidOptionsOnly, JSON.stringify(availableOptions), JSON.stringify(options), JSON.stringify(operators)]);
 
   // Read-first STATUS / BOX for one option — lifted to component scope so the
   // status boxes (renderCompact) and the header's "needs attention" count share
@@ -1437,7 +1498,13 @@ export const FormEngine = ({
     (name: string, hidden = false): TReadFirstStatus => {
       if (hidden) return 'optional';
       const schema = options?.[name];
-      const type = (schema?.ui_type || schema?.type) as TQorusType;
+      const type = getOptionFieldStorageType(
+        name,
+        (availableOptions as TQorusForm)?.[name]?.type,
+        options,
+        operators,
+        (availableOptions as TQorusForm)?.[name]?.op
+      );
       const value = (availableOptions as TQorusForm)?.[name]?.value;
       const empty = isOptionValueEmpty(value);
       const reqGroups = (schema?.required_groups as string[] | undefined) || [];
@@ -1461,6 +1528,7 @@ export const FormEngine = ({
     [
       JSON.stringify(options),
       JSON.stringify(availableOptions),
+      JSON.stringify(operators),
       isOptionValid,
       requiredGroupsInfo,
       schemaMsgIntent,
@@ -1908,7 +1976,7 @@ export const FormEngine = ({
               options?.[optionName]?.allowed_values,
               other.op
             )}
-            ui_type={type}
+            ui_type={(options?.[optionName]?.ui_type as TQorusType) || type}
             name={optionName}
             uniqueName={`${uniqueName ? `${uniqueName}.` : `${name ? `${name}.` : ''}`}${optionName}`}
             onChange={
@@ -2057,6 +2125,7 @@ export const FormEngine = ({
       getTypeForOption,
       isOptionValid,
       confirmAction,
+      optionActions,
       renderOption,
       theme,
       cText,
@@ -2102,6 +2171,7 @@ export const FormEngine = ({
       getTypeForOption,
       isOptionValid,
       confirmAction,
+      optionActions,
       renderOption,
       theme,
       cText,
@@ -2238,7 +2308,13 @@ export const FormEngine = ({
       const isFieldInvalid = (name: string) =>
         !isOptionValid(
           name,
-          (options?.[name]?.ui_type || options?.[name]?.type) as TQorusType,
+          getOptionFieldStorageType(
+            name,
+            (shownOptions as TQorusForm)[name]?.type,
+            options,
+            operators,
+            (shownOptions as TQorusForm)[name]?.op
+          ),
           (shownOptions as TQorusForm)[name]?.value
         );
       const comparator = (a: { name: string }, b: { name: string }): number => {
@@ -2347,7 +2423,7 @@ export const FormEngine = ({
           optionField={
             entry.hidden ?
               ({
-                type: (options?.[entry.name]?.ui_type || options?.[entry.name]?.type) as TQorusType,
+                type: getOptionSchemaStorageType(options?.[entry.name]),
                 value: undefined,
               } as IQorusFormField)
             : ((shownOptions as TQorusForm)[entry.name] as IQorusFormField)

--- a/src/components/form/engine/FormEngine.tsx
+++ b/src/components/form/engine/FormEngine.tsx
@@ -1856,14 +1856,23 @@ export const FormEngine = ({
       suppressSchemaMessages?: boolean
     ) => {
       const operatorParts = fixOperatorValue(other.op);
-      // The RENDERER type for this row. The schema's `ui_type` wins because it
-      // names the editor, and a renderer-only one never reaches the field's
-      // stored `type` any more; the remaining fallbacks keep the row rendering
-      // when a server-driven schema has not arrived yet (type would be
-      // undefined) rather than crashing on it.
+      // The RENDERER type for this row — which editor mounts. Distinct from the
+      // storage type on the value envelope: a `richtext` field stores a string
+      // but must render the richtext editor, so `ui_type` wins here.
+      //
+      // The exception is an any-like `ui_type`. Those schemas say
+      // `ui_type: 'any'` precisely so the user can pick a concrete type, and
+      // that pick lives on the field's stored `type` — letting 'any' win would
+      // pin the row to the untyped editor forever.
+      //
+      // The trailing fallbacks keep the row rendering when a server-driven
+      // schema has not arrived yet (`type` undefined) instead of crashing.
+      const schemaUiType = options?.[optionName]?.ui_type as TQorusType;
+      const uiTypeIsAnyLike = schemaUiType === 'any' || schemaUiType === 'auto';
       const resolvedType =
-        (options?.[optionName]?.ui_type as TQorusType) ||
+        (schemaUiType && !uiTypeIsAnyLike ? schemaUiType : undefined) ||
         type ||
+        schemaUiType ||
         (options?.[optionName]?.type as TQorusType) ||
         'any';
       return (
@@ -2011,7 +2020,10 @@ export const FormEngine = ({
             }
             templates={templates.value}
             {...getTypeAndCanBeNull(
-              (type as TQorusType) || (options?.[optionName]?.type as TQorusType),
+              // The RENDERER type picks the editor — the storage type lives on
+              // the value envelope. Passing storage here rendered a `richtext`
+              // field as a plain string input.
+              resolvedType,
               options?.[optionName]?.allowed_values,
               other.op
             )}

--- a/src/components/form/engine/FormEngine.tsx
+++ b/src/components/form/engine/FormEngine.tsx
@@ -40,6 +40,7 @@ import {
 } from '@qoretechnologies/ts-toolkit';
 import { resolveOptionActions, TOptionActions } from './optionActions';
 import { createRendererOnlyUiTypeCheck, isRendererOnlyUiType } from './rendererTypes';
+import { useCanHover, useIsNarrowViewport } from '../../../hooks/useMediaQuery';
 import { cloneDeep, findKey, flatten, forEach, isEqual, isPlainObject, last } from 'lodash';
 import isArray from 'lodash/isArray';
 import map from 'lodash/map';
@@ -606,6 +607,20 @@ export interface IFormEngineProps extends Omit<IReqoreCollectionProps, 'onChange
    */
   optionActions?: TOptionActions;
   /**
+   * Whether per-option injected actions collapse into the row's overflow menu
+   * instead of rendering as inline buttons.
+   *
+   * `'auto'` (default) collapses when the device cannot hover or the viewport is
+   * narrow — on a phone a hover-gated action would otherwise be unreachable, and
+   * a row has no width for a button strip. `'always'` / `'never'` force it, which
+   * consumers can use for a known-mobile surface and stories use to capture the
+   * collapsed state deterministically.
+   *
+   * Actions beyond `MAX_INLINE_OPTION_ACTIONS` always overflow into the menu, so
+   * a consumer injecting many actions can never blow out the row.
+   */
+  optionActionsCollapse?: 'auto' | 'always' | 'never';
+  /**
    * SEAM (reqraft): consumer-injected field editors for types reqraft doesn't
    * ship (IDE domain fields). Keyed by field `type`/`ui_type`; forwarded through
    * `TemplateField` to the `AutoFormField` override seam.
@@ -705,6 +720,7 @@ export const FormEngine = ({
   optionsLoader,
   onValidityChange,
   optionActions,
+  optionActionsCollapse = 'auto',
   componentOverrides,
   rendererOnlyUiTypes,
   inheritedFromParent,
@@ -717,6 +733,14 @@ export const FormEngine = ({
     () => createRendererOnlyUiTypeCheck(rendererOnlyUiTypes),
     [JSON.stringify(rendererOnlyUiTypes)]
   );
+  // Resolved once here rather than per row — every CompactRow reads the answer
+  // off the context instead of opening its own matchMedia subscription.
+  const canHover = useCanHover();
+  const isNarrowViewport = useIsNarrowViewport();
+  const collapseOptionActions =
+    optionActionsCollapse === 'always' ? true
+    : optionActionsCollapse === 'never' ? false
+    : !canHover || isNarrowViewport;
   const [options, setOptions] = useState<IQorusFormSchema | undefined>(rest?.options || undefined);
   // optionsLoader lifecycle: loading feeds the skeleton gate, error the banner.
   const [optionsLoading, setOptionsLoading] = useState<boolean>(!!optionsLoader && !rest?.options);
@@ -2177,6 +2201,7 @@ export const FormEngine = ({
       isOptionValid,
       confirmAction,
       optionActions,
+      collapseOptionActions,
       renderOption,
       theme,
       cText,
@@ -2223,6 +2248,7 @@ export const FormEngine = ({
       isOptionValid,
       confirmAction,
       optionActions,
+      collapseOptionActions,
       renderOption,
       theme,
       cText,

--- a/src/components/form/engine/FormEngine.tsx
+++ b/src/components/form/engine/FormEngine.tsx
@@ -15,10 +15,7 @@ import {
 } from '@qoretechnologies/reqore';
 import { IReqoreCollectionProps } from '@qoretechnologies/reqore/dist/components/Collection';
 import { IReqoreCollectionItemProps } from '@qoretechnologies/reqore/dist/components/Collection/item';
-import {
-  IReqorePanelAction,
-  IReqorePanelProps,
-} from '@qoretechnologies/reqore/dist/components/Panel';
+import { IReqorePanelProps } from '@qoretechnologies/reqore/dist/components/Panel';
 import { IReqoreFormTemplates } from '@qoretechnologies/reqore/dist/components/Textarea';
 import { TReqoreIntent } from '@qoretechnologies/reqore/dist/constants/theme';
 import {
@@ -41,6 +38,8 @@ import {
   TQorusFormOperatorValue,
   TQorusType,
 } from '@qoretechnologies/ts-toolkit';
+import { resolveOptionActions, TOptionActions } from './optionActions';
+import { createRendererOnlyUiTypeCheck, isRendererOnlyUiType } from './rendererTypes';
 import { cloneDeep, findKey, flatten, forEach, isEqual, isPlainObject, last } from 'lodash';
 import isArray from 'lodash/isArray';
 import map from 'lodash/map';
@@ -267,24 +266,18 @@ export const fixOperatorValue = (operator: TOperatorValue): (string | null | und
   return isArray(operator) ? operator : [operator];
 };
 
-const RENDERER_ONLY_UI_TYPES = new Set([
-  'active-windows',
-  'alert-threshold',
-  'code-editor',
-  'cron',
-  'dpql',
-  'processor-mappings',
-  'schema-definition',
-  'test-cases',
-  'test-value-contract',
-  'tool-catalog',
-]);
+/**
+ * The renderer-only predicate. Defaults to reqraft's built-ins; a FormEngine
+ * instance passes its own (built-ins + the `rendererOnlyUiTypes` prop) so a
+ * consumer's injected editors are recognised too. See `./rendererTypes`.
+ */
+type TRendererOnlyCheck = (type?: TQorusType | TQorusType[]) => boolean;
 
-const isRendererOnlyUiType = (type?: TQorusType | TQorusType[]): boolean =>
-  typeof type === 'string' && RENDERER_ONLY_UI_TYPES.has(type);
-
-const getOptionSchemaStorageType = (option?: TQorusFormFieldSchema): TQorusType =>
-  ((isRendererOnlyUiType(option?.ui_type)
+const getOptionSchemaStorageType = (
+  option?: TQorusFormFieldSchema,
+  isRendererOnly: TRendererOnlyCheck = isRendererOnlyUiType
+): TQorusType =>
+  ((isRendererOnly(option?.ui_type)
     ? option?.type || option?.ui_type
     : option?.ui_type || option?.type) || 'any') as TQorusType;
 
@@ -293,13 +286,14 @@ const getOptionFieldStorageType = (
   fieldType: TQorusType | TQorusType[] | undefined,
   schema?: IQorusFormSchema,
   operators?: IOperatorsSchema,
-  operatorData?: TOperatorValue
+  operatorData?: TOperatorValue,
+  isRendererOnly: TRendererOnlyCheck = isRendererOnlyUiType
 ): TQorusType => {
   const schemaOption = schema?.[optionName];
   const storedType =
-    fieldType && !(fieldType === schemaOption?.ui_type && isRendererOnlyUiType(fieldType))
+    fieldType && !(fieldType === schemaOption?.ui_type && isRendererOnly(fieldType))
       ? fieldType
-      : getOptionSchemaStorageType(schemaOption);
+      : getOptionSchemaStorageType(schemaOption, isRendererOnly);
 
   return getType(storedType as TQorusType, operators, operatorData);
 };
@@ -316,7 +310,8 @@ export const OptionsContext = createContext<{
 export const fixOptions = (
   value: TQorusForm | TQorusFlatForm = {},
   options: IQorusFormSchema,
-  operators?: IOperatorsSchema
+  operators?: IOperatorsSchema,
+  isRendererOnly: TRendererOnlyCheck = isRendererOnlyUiType
 ): TQorusForm => {
   const fixedValue = cloneDeep(value);
 
@@ -329,7 +324,7 @@ export const fixOptions = (
     ) {
       let obj: IQorusFormField;
       const type = getType(
-        getOptionSchemaStorageType(option),
+        getOptionSchemaStorageType(option, isRendererOnly),
         operators,
         (fixedValue[name] as IQorusFormField)?.op
       );
@@ -370,7 +365,7 @@ export const fixOptions = (
           isUntypedEnvelope ? (newOption as IQorusFormField).value : newOption;
         const fixedOption: IQorusFormField = {
           type: getType(
-            getOptionSchemaStorageType(options?.[optionName]),
+            getOptionSchemaStorageType(options?.[optionName], isRendererOnly),
             operators,
             (newOption as IQorusFormField)?.op
           ),
@@ -384,12 +379,12 @@ export const fixOptions = (
         newOption = fixedOption;
       } else if (
         newOption.type === options?.[optionName]?.ui_type &&
-        isRendererOnlyUiType(newOption.type)
+        isRendererOnly(newOption.type)
       ) {
         newOption = {
           ...newOption,
           type: getType(
-            getOptionSchemaStorageType(options?.[optionName]),
+            getOptionSchemaStorageType(options?.[optionName], isRendererOnly),
             operators,
             newOption.op
           ),
@@ -598,19 +593,22 @@ export interface IFormEngineProps extends Omit<IReqoreCollectionProps, 'onChange
    * option's name/schema/value (the context the IDE's `AiAssistanceAction`
    * captures); the consumer injects the button, reqraft stays AI-free.
    */
-  optionActions?:
-    | IReqorePanelAction[]
-    | ((context: {
-        name: string;
-        schema: IQorusFormSchema[string];
-        value?: TOption;
-      }) => IReqorePanelAction[]);
+  optionActions?: TOptionActions;
   /**
    * SEAM (reqraft): consumer-injected field editors for types reqraft doesn't
    * ship (IDE domain fields). Keyed by field `type`/`ui_type`; forwarded through
    * `TemplateField` to the `AutoFormField` override seam.
    */
   componentOverrides?: Record<string, React.FC<any>>;
+  /**
+   * The `ui_type` names among `componentOverrides` that select a bespoke editor
+   * but store their value as the schema's plainer `type` (a `cron` editor stores
+   * a string). Declaring them here keeps the field's stored `type` correct —
+   * without it the renderer name is written into the value and validation and
+   * round-tripping both break. Merged with reqraft's own built-in list, so a
+   * consumer's new editor no longer needs a reqraft release to be handled.
+   */
+  rendererOnlyUiTypes?: string[];
 
   /**
    * Bag of values forwarded from an outer FormEngine scope, used as a
@@ -697,11 +695,17 @@ export const FormEngine = ({
   onValidityChange,
   optionActions,
   componentOverrides,
+  rendererOnlyUiTypes,
   inheritedFromParent,
   autoFocusFirstRequired,
   initialExpandedOptions,
   ...rest
 }: IFormEngineProps) => {
+  // Built-ins + whatever the consumer declared for its own injected editors.
+  const isRendererOnly = useMemo(
+    () => createRendererOnlyUiTypeCheck(rendererOnlyUiTypes),
+    [JSON.stringify(rendererOnlyUiTypes)]
+  );
   const [options, setOptions] = useState<IQorusFormSchema | undefined>(rest?.options || undefined);
   // optionsLoader lifecycle: loading feeds the skeleton gate, error the banner.
   const [optionsLoading, setOptionsLoading] = useState<boolean>(!!optionsLoader && !rest?.options);
@@ -837,7 +841,7 @@ export const FormEngine = ({
     fields: TQorusForm | TQorusFlatForm;
     meta?: IOptionsOnChangeMeta;
   }>(() => ({
-    fields: fixOptions(value, options || {}),
+    fields: fixOptions(value, options || {}, undefined, isRendererOnly),
     meta: undefined,
   }));
   const originalValue = useRef<any>();
@@ -930,7 +934,7 @@ export const FormEngine = ({
           setOptions({});
           return;
         }
-        setLocalValue({ fields: fixOptions(value, data.data), meta: undefined });
+        setLocalValue({ fields: fixOptions(value, data.data, undefined, isRendererOnly), meta: undefined });
         if (!operatorsUrl) {
           setLoading(false);
         }
@@ -975,7 +979,7 @@ export const FormEngine = ({
         }
         setOptions(data.data);
         onOptionsLoaded?.(data.data);
-        setLocalValue({ fields: fixOptions({}, data.data), meta: undefined });
+        setLocalValue({ fields: fixOptions({}, data.data, undefined, isRendererOnly), meta: undefined });
       })();
     }
   }, [url, customUrl]);
@@ -999,7 +1003,7 @@ export const FormEngine = ({
   }, [operatorsUrl]);
 
   useUpdateEffect(() => {
-    const fixedValue = fixOptions(value, options || {});
+    const fixedValue = fixOptions(value, options || {}, undefined, isRendererOnly);
 
     // When the value we're receiving is the one we just emitted AND fixOptions has nothing to
     // meaningfully add or change, skip the update. This breaks the controlled-component loop for
@@ -1023,19 +1027,19 @@ export const FormEngine = ({
     }
 
     setLocalValue?.({ fields: fixedValue, meta: undefined });
-  }, [JSON.stringify(options), JSON.stringify(value)]);
+  }, [JSON.stringify(options), JSON.stringify(value), isRendererOnly]);
 
   const handleValueChange = useCallback(
     (optionName: string, val?: any, _type?: string, isFunction?: boolean) => {
       setLocalValue(({ fields = {} }) => {
-        const schemaType = getOptionSchemaStorageType(options?.[optionName]);
+        const schemaType = getOptionSchemaStorageType(options?.[optionName], isRendererOnly);
         const isAnyLike = schemaType === 'any' || schemaType === 'auto';
         // For any/auto schema types, preserve the user's chosen type stored in the field
         const resolvedSchemaType =
           isAnyLike && (fields[optionName] as IQorusFormField)?.type
             ? ((fields[optionName] as IQorusFormField).type as TQorusType)
             : (fields[optionName] as IQorusFormField)?.type === options?.[optionName]?.ui_type &&
-                isRendererOnlyUiType((fields[optionName] as IQorusFormField)?.type)
+                isRendererOnly((fields[optionName] as IQorusFormField)?.type)
               ? schemaType
               : schemaType || ((fields[optionName] as IQorusFormField)?.type as TQorusType);
         const type =
@@ -1120,6 +1124,7 @@ export const FormEngine = ({
     [
       onSingleOptionsChange,
       onDependableOptionChange,
+      isRendererOnly,
       JSON.stringify(options),
       JSON.stringify(operators),
     ]
@@ -1240,7 +1245,7 @@ export const FormEngine = ({
         optionName as string,
         getDefaultValue(options?.[optionName as string]),
         getTypeAndCanBeNull(
-          getOptionSchemaStorageType(options?.[optionName as string]),
+          getOptionSchemaStorageType(options?.[optionName as string], isRendererOnly),
           options?.[optionName as string]?.allowed_values
         ).type
       );
@@ -1278,7 +1283,8 @@ export const FormEngine = ({
           (option as IQorusFormField)?.type,
           options,
           operators,
-          (option as IQorusFormField)?.op
+          (option as IQorusFormField)?.op,
+          isRendererOnly
         );
 
         if (!isPlainObject(option)) {
@@ -1297,6 +1303,7 @@ export const FormEngine = ({
         };
       }, {});
   }, [
+    isRendererOnly,
     JSON.stringify(fixedValue),
     JSON.stringify(options),
     unavailableOptionsCount.current,
@@ -1398,7 +1405,8 @@ export const FormEngine = ({
           (option as IQorusFormField).type,
           options,
           operators,
-          (option as IQorusFormField).op
+          (option as IQorusFormField).op,
+          isRendererOnly
         );
         const optionValue = (option as IQorusFormField).value;
 
@@ -1441,6 +1449,7 @@ export const FormEngine = ({
       invalidFields,
     };
   }, [
+    isRendererOnly,
     JSON.stringify(availableOptions),
     JSON.stringify(options),
     JSON.stringify(operators),
@@ -1467,7 +1476,8 @@ export const FormEngine = ({
               (option as IQorusFormField).type,
               options,
               operators,
-              (option as IQorusFormField).op
+              (option as IQorusFormField).op,
+              isRendererOnly
             ),
             (option as IQorusFormField).value
           )
@@ -1478,7 +1488,13 @@ export const FormEngine = ({
       },
       {}
     );
-  }, [showInvalidOptionsOnly, JSON.stringify(availableOptions), JSON.stringify(options), JSON.stringify(operators)]);
+  }, [
+    showInvalidOptionsOnly,
+    isRendererOnly,
+    JSON.stringify(availableOptions),
+    JSON.stringify(options),
+    JSON.stringify(operators),
+  ]);
 
   // Read-first STATUS / BOX for one option — lifted to component scope so the
   // status boxes (renderCompact) and the header's "needs attention" count share
@@ -1503,7 +1519,8 @@ export const FormEngine = ({
         (availableOptions as TQorusForm)?.[name]?.type,
         options,
         operators,
-        (availableOptions as TQorusForm)?.[name]?.op
+        (availableOptions as TQorusForm)?.[name]?.op,
+        isRendererOnly
       );
       const value = (availableOptions as TQorusForm)?.[name]?.value;
       const empty = isOptionValueEmpty(value);
@@ -1526,6 +1543,7 @@ export const FormEngine = ({
       });
     },
     [
+      isRendererOnly,
       JSON.stringify(options),
       JSON.stringify(availableOptions),
       JSON.stringify(operators),
@@ -1794,10 +1812,10 @@ export const FormEngine = ({
           next[optionName] = value as IQorusFormField;
         }
       });
-      return { fields: fixOptions(next, options || {}, operators), meta: undefined };
+      return { fields: fixOptions(next, options || {}, operators, isRendererOnly), meta: undefined };
     });
     setRequiredOnly(false);
-  }, [JSON.stringify(options), JSON.stringify(operators)]);
+  }, [JSON.stringify(options), JSON.stringify(operators), isRendererOnly]);
 
   const getCustomMenuTemplateItems = useCallback<(optionName: string) => TCustomTemplateItems>(
     (optionName) => {
@@ -2313,7 +2331,8 @@ export const FormEngine = ({
             (shownOptions as TQorusForm)[name]?.type,
             options,
             operators,
-            (shownOptions as TQorusForm)[name]?.op
+            (shownOptions as TQorusForm)[name]?.op,
+            isRendererOnly
           ),
           (shownOptions as TQorusForm)[name]?.value
         );
@@ -2423,7 +2442,7 @@ export const FormEngine = ({
           optionField={
             entry.hidden ?
               ({
-                type: getOptionSchemaStorageType(options?.[entry.name]),
+                type: getOptionSchemaStorageType(options?.[entry.name], isRendererOnly),
                 value: undefined,
               } as IQorusFormField)
             : ((shownOptions as TQorusForm)[entry.name] as IQorusFormField)
@@ -2884,13 +2903,11 @@ export const FormEngine = ({
                 // option's schema as context). The consumer (the IDE) injects
                 // it; same factory pattern as the ExpressionBuilder's
                 // `extraActions`.
-                ...(typeof optionActions === 'function' ?
-                  optionActions({
-                    name: optionName,
-                    schema: options[optionName],
-                    value: availableOptions?.[optionName] as TOption,
-                  })
-                : (optionActions ?? [])),
+                ...resolveOptionActions(optionActions, {
+                  name: optionName,
+                  schema: options[optionName],
+                  value: availableOptions?.[optionName] as TOption,
+                }),
                 {
                   size: 'tiny',
                   icon: 'FullscreenLine',

--- a/src/components/form/engine/FormEngineRemote.stories.tsx
+++ b/src/components/form/engine/FormEngineRemote.stories.tsx
@@ -11,6 +11,7 @@
 import { StoryObj } from '@storybook/react-vite';
 import { expect, fn, userEvent, waitFor, within } from 'storybook/test';
 import { useState } from 'react';
+import { _testsClickButton, sleep } from '../../../stories/Tests/utils';
 import { StoryMeta } from '../../../types';
 import { FormEngine } from './FormEngine';
 
@@ -358,12 +359,161 @@ export const InjectedCompactOptionActions: Story = {
     });
 
     // The hover-only action carries the CSS gate; the always-on one does not.
-    expect(
-      document.querySelectorAll('.option-compact-ai-assist.options-injected-action-hover').length
-    ).toBe(rowCount);
+    const hoverAction = document.querySelector(
+      '.option-compact-ai-assist.options-injected-action-hover'
+    ) as HTMLElement;
+    expect(hoverAction).toBeTruthy();
     expect(
       document.querySelectorAll('.option-compact-always.options-injected-action-hover').length
     ).toBe(0);
+
+    // Actually exercise the reveal condition rather than just asserting the
+    // class is present: gated the action is transparent and not hit-testable.
+    expect(getComputedStyle(hoverAction).opacity).toBe('0');
+    expect(getComputedStyle(hoverAction).pointerEvents).toBe('none');
+
+    // Focus is the reveal path a test can drive: the gate keys on
+    // `:hover, :focus-within`, and a synthetic mouse event does NOT put a real
+    // browser into `:hover`. Focusing the action is also the keyboard route a
+    // user takes, so this covers the accessibility path at the same time.
+    hoverAction.focus();
+    await waitFor(() => {
+      expect(getComputedStyle(hoverAction).opacity).toBe('1');
+      expect(getComputedStyle(hoverAction).pointerEvents).toBe('auto');
+    });
+
+    // Left revealed so the captured frame shows the action rather than an
+    // empty slot — the whole point of the story.
+    await sleep(200);
+  },
+};
+
+/**
+ * The no-hover case. A touch device never fires `:hover`, so a hover-gated
+ * action would be permanently unreachable; instead every injected action moves
+ * into the row's own overflow menu. `optionActionsCollapse='always'` forces the
+ * branch that `(hover: none)`/`(pointer: coarse)` picks on a real phone, which a
+ * desktop browser cannot emulate.
+ */
+export const InjectedCompactOptionActionsMobile: Story = {
+  args: {
+    name: 'compactOptionActionsMobile',
+    compact: true,
+    options: BASIC_SCHEMA as any,
+    optionActionsCollapse: 'always',
+    optionActions: ({ name }) => [
+      {
+        icon: 'MagicLine',
+        className: 'option-compact-ai-assist',
+        tooltip: `AI assistance for ${name}`,
+        show: 'hover',
+        size: 'tiny',
+        fixed: true,
+      },
+      {
+        icon: 'InformationLine',
+        className: 'option-compact-always',
+        tooltip: `Details for ${name}`,
+        size: 'tiny',
+        fixed: true,
+      },
+    ],
+  },
+  parameters: {
+    qlip: { viewport: { width: 420, height: 900 } },
+    docs: {
+      description: {
+        story:
+          'Renders the compact rows at phone width with injected actions collapsed into each row\'s overflow menu — the no-hover path, where a hover-gated button would otherwise be unreachable. The menu is opened so the actions are visible.',
+      },
+    },
+  },
+  async play() {
+    await waitFor(
+      () => expect(document.querySelectorAll('.readfirst-row').length).toBeGreaterThan(0),
+      { timeout: 10000 }
+    );
+
+    // Collapsed: no inline injected buttons at all, one overflow menu per row.
+    const rowCount = document.querySelectorAll('.readfirst-row').length;
+    await waitFor(() => {
+      expect(document.querySelectorAll('.options-injected-actions-menu').length).toBe(rowCount);
+    });
+    expect(document.querySelectorAll('.option-compact-ai-assist').length).toBe(0);
+    expect(document.querySelectorAll('.option-compact-always').length).toBe(0);
+
+    // Both actions are reachable from the menu — the reason the collapse exists.
+    await _testsClickButton({ selector: '.options-injected-actions-menu', nth: 0 });
+    await waitFor(
+      () => {
+        const labels = Array.from(document.querySelectorAll('.reqore-menu-item')).map(
+          (item) => item.textContent ?? ''
+        );
+        expect(labels.some((label) => label.includes('AI assistance for'))).toBe(true);
+        expect(labels.some((label) => label.includes('Details for'))).toBe(true);
+      },
+      { timeout: 10000 }
+    );
+  },
+};
+
+/**
+ * Many injected actions. Beyond the inline cap the extras overflow into the
+ * row's menu instead of squeezing the value out of the row, so a consumer can
+ * inject any number without breaking the layout.
+ */
+export const InjectedCompactOptionActionsMany: Story = {
+  args: {
+    name: 'compactOptionActionsMany',
+    compact: true,
+    options: BASIC_SCHEMA as any,
+    optionActions: ({ name }) =>
+      ['MagicLine', 'InformationLine', 'FileCopyLine', 'DeleteBinLine', 'ShareLine'].map(
+        (icon, index) => ({
+          icon: icon as any,
+          className: `option-compact-many-${index}`,
+          tooltip: `${icon} for ${name}`,
+          size: 'tiny',
+          fixed: true,
+        })
+      ),
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders the compact rows with five injected actions per option — the first two stay inline and the remaining three collapse into the row\'s overflow menu, which is opened here to show them.',
+      },
+    },
+  },
+  async play() {
+    await waitFor(
+      () => expect(document.querySelectorAll('.readfirst-row').length).toBeGreaterThan(0),
+      { timeout: 10000 }
+    );
+
+    const rowCount = document.querySelectorAll('.readfirst-row').length;
+
+    // Only the first two render inline; the rest are in the menu.
+    await waitFor(() => {
+      expect(document.querySelectorAll('.option-compact-many-0').length).toBe(rowCount);
+      expect(document.querySelectorAll('.option-compact-many-1').length).toBe(rowCount);
+    });
+    expect(document.querySelectorAll('.option-compact-many-2').length).toBe(0);
+    expect(document.querySelectorAll('.option-compact-many-4').length).toBe(0);
+    expect(document.querySelectorAll('.options-injected-actions-menu').length).toBe(rowCount);
+
+    await _testsClickButton({ selector: '.options-injected-actions-menu', nth: 0 });
+    await waitFor(
+      () => {
+        const labels = Array.from(document.querySelectorAll('.reqore-menu-item')).map(
+          (item) => item.textContent ?? ''
+        );
+        expect(labels.some((label) => label.includes('DeleteBinLine for'))).toBe(true);
+        expect(labels.some((label) => label.includes('ShareLine for'))).toBe(true);
+      },
+      { timeout: 10000 }
+    );
   },
 };
 

--- a/src/components/form/engine/FormEngineRemote.stories.tsx
+++ b/src/components/form/engine/FormEngineRemote.stories.tsx
@@ -308,6 +308,47 @@ export const InjectedOptionActions: Story = {
 };
 
 /**
+ * The same injected actions seam must also work in compact/read-first mode. The
+ * IDE uses this path for option-based forms and relies on the action slot for
+ * small per-field Qonsole controls.
+ */
+export const InjectedCompactOptionActions: Story = {
+  args: {
+    name: 'compactOptionActionsSeam',
+    compact: true,
+    options: BASIC_SCHEMA as any,
+    optionActions: ({ name }) => [
+      {
+        icon: 'MagicLine',
+        className: 'option-compact-ai-assist',
+        tooltip: `AI assistance for ${name}`,
+        show: true,
+        size: 'tiny',
+        fixed: true,
+      },
+    ],
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders compact FormEngine rows with injected per-option actions so consumers can attach field-local actions without leaving read-first mode.',
+      },
+    },
+  },
+  async play() {
+    await waitFor(() => expect(document.querySelectorAll('.readfirst-row').length).toBeGreaterThan(0), {
+      timeout: 10000,
+    });
+    await waitFor(() => {
+      expect(document.querySelectorAll('.option-compact-ai-assist').length).toBe(
+        document.querySelectorAll('.readfirst-row').length
+      );
+    });
+  },
+};
+
+/**
  * Opt-in template fetching: `interfaceContext` makes `useTemplates` fetch
  * `system/getContextData` (the IDE's behavior); without it, no request is
  * made (the original reqraft stub behavior).

--- a/src/components/form/engine/FormEngineRemote.stories.tsx
+++ b/src/components/form/engine/FormEngineRemote.stories.tsx
@@ -341,7 +341,7 @@ export const InjectedCompactOptionActions: Story = {
     docs: {
       description: {
         story:
-          'Renders compact FormEngine rows with two injected per-option actions: one always visible, one declared `show: "hover"` that stays transparent until its row is hovered or focused.',
+          'Renders compact FormEngine rows with two injected per-option actions: one always visible, one declared `show: "hover"` that stays transparent until its row is hovered or focused. Hover-gating applies only where the pointer can hover — on touch both collapse into the row\'s overflow menu instead, so neither is ever hover-only.',
       },
     },
   },
@@ -514,6 +514,111 @@ export const InjectedCompactOptionActionsMany: Story = {
       },
       { timeout: 10000 }
     );
+  },
+};
+
+// A compact row renders the SAME logical state three ways — the read row, the
+// inline editor, and the edit card (complex types get the card). An injected
+// action has to survive all three, and per the affordance-parity rule each
+// branch needs its own story: the branch without one is where a dead action
+// hides, because the branch under test is the branch that works.
+const BRANCH_SCHEMA = {
+  host: {
+    type: 'string',
+    display_name: 'Host',
+    short_desc: 'Edits inline inside the row',
+    preselected: true,
+    default_value: 'localhost',
+  },
+  notes: {
+    type: 'string',
+    ui_type: 'long-string',
+    display_name: 'Notes',
+    short_desc: 'A complex type — edits in the card branch',
+    preselected: true,
+    // Needs a value: an empty optional field sits in the collapsed "Optional"
+    // group, where `initialExpandedOptions` has nothing to open.
+    default_value: 'Notes that are long enough to want the card editor.',
+  },
+};
+
+const branchAction = ({ name }: { name: string }) => [
+  {
+    icon: 'MagicLine' as const,
+    className: 'option-branch-action',
+    tooltip: `AI assistance for ${name}`,
+    size: 'tiny' as const,
+    fixed: true,
+  },
+];
+
+/**
+ * Branch 1 of 3: the INLINE editor. A simple type opens inside the row itself,
+ * and the injected action has to be reachable there, not just on the read row.
+ */
+export const InjectedOptionActionsInlineEditing: Story = {
+  args: {
+    name: 'compactOptionActionsInline',
+    compact: true,
+    options: BRANCH_SCHEMA as any,
+    initialExpandedOptions: ['host'],
+    optionActions: branchAction,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders the compact form with the simple `host` field already open, so it edits inline inside the row — the injected per-option action is asserted inside that inline branch.',
+      },
+    },
+  },
+  async play() {
+    await waitFor(
+      () => expect(document.querySelector('.readfirst-row-editing')).toBeTruthy(),
+      { timeout: 10000 }
+    );
+
+    // Scoped to the branch on purpose: a global query would pass on the read
+    // row's copy and prove nothing about the inline editor.
+    await waitFor(() => {
+      expect(
+        document.querySelector('.readfirst-row-editing .option-branch-action')
+      ).toBeTruthy();
+    });
+  },
+};
+
+/**
+ * Branch 2 of 3: the EDIT CARD. A complex type (`long-string`) is too tall to
+ * edit in-row, so it opens as a card — a different subtree, and historically
+ * where an action wired only in the other branch went missing.
+ */
+export const InjectedOptionActionsEditCard: Story = {
+  args: {
+    name: 'compactOptionActionsCard',
+    compact: true,
+    options: BRANCH_SCHEMA as any,
+    initialExpandedOptions: ['notes'],
+    optionActions: branchAction,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders the compact form with the complex `notes` field already open, so it edits in the card branch rather than in-row — the injected per-option action is asserted inside that card.',
+      },
+    },
+  },
+  async play() {
+    await waitFor(() => expect(document.querySelector('.options-readfirst-card')).toBeTruthy(), {
+      timeout: 10000,
+    });
+
+    await waitFor(() => {
+      expect(
+        document.querySelector('.options-readfirst-card .option-branch-action')
+      ).toBeTruthy();
+    });
   },
 };
 

--- a/src/components/form/engine/FormEngineRemote.stories.tsx
+++ b/src/components/form/engine/FormEngineRemote.stories.tsx
@@ -580,11 +580,25 @@ export const InjectedOptionActionsInlineEditing: Story = {
 
     // Scoped to the branch on purpose: a global query would pass on the read
     // row's copy and prove nothing about the inline editor.
-    await waitFor(() => {
-      expect(
-        document.querySelector('.readfirst-row-editing .option-branch-action')
-      ).toBeTruthy();
+    const injected = await waitFor(() => {
+      const el = document.querySelector(
+        '.readfirst-row-editing .option-branch-action'
+      ) as HTMLElement;
+      expect(el).toBeTruthy();
+      return el;
     });
+
+    // The injected action must match the size of the row's own actions. The
+    // fixture deliberately asks for `size: 'tiny'` — the row overrides it,
+    // because a consumer-sized button rendered visibly smaller than the revert
+    // and More buttons beside it (qlip build #57 rejection).
+    const neighbour = document.querySelector(
+      '.readfirst-row-editing .options-readfirst-more'
+    ) as HTMLElement;
+    expect(neighbour).toBeTruthy();
+    expect(injected.getBoundingClientRect().height).toBe(
+      neighbour.getBoundingClientRect().height
+    );
   },
 };
 

--- a/src/components/form/engine/FormEngineRemote.stories.tsx
+++ b/src/components/form/engine/FormEngineRemote.stories.tsx
@@ -322,7 +322,15 @@ export const InjectedCompactOptionActions: Story = {
         icon: 'MagicLine',
         className: 'option-compact-ai-assist',
         tooltip: `AI assistance for ${name}`,
-        show: true,
+        // The shape the IDE passes on the classic path — hover-gated here too.
+        show: 'hover',
+        size: 'tiny',
+        fixed: true,
+      },
+      {
+        icon: 'InformationLine',
+        className: 'option-compact-always',
+        tooltip: `Details for ${name}`,
         size: 'tiny',
         fixed: true,
       },
@@ -332,19 +340,30 @@ export const InjectedCompactOptionActions: Story = {
     docs: {
       description: {
         story:
-          'Renders compact FormEngine rows with injected per-option actions so consumers can attach field-local actions without leaving read-first mode.',
+          'Renders compact FormEngine rows with two injected per-option actions: one always visible, one declared `show: "hover"` that stays transparent until its row is hovered or focused.',
       },
     },
   },
   async play() {
-    await waitFor(() => expect(document.querySelectorAll('.readfirst-row').length).toBeGreaterThan(0), {
-      timeout: 10000,
-    });
+    await waitFor(
+      () => expect(document.querySelectorAll('.readfirst-row').length).toBeGreaterThan(0),
+      { timeout: 10000 }
+    );
+
+    const rowCount = document.querySelectorAll('.readfirst-row').length;
+
     await waitFor(() => {
-      expect(document.querySelectorAll('.option-compact-ai-assist').length).toBe(
-        document.querySelectorAll('.readfirst-row').length
-      );
+      expect(document.querySelectorAll('.option-compact-always').length).toBe(rowCount);
+      expect(document.querySelectorAll('.option-compact-ai-assist').length).toBe(rowCount);
     });
+
+    // The hover-only action carries the CSS gate; the always-on one does not.
+    expect(
+      document.querySelectorAll('.option-compact-ai-assist.options-injected-action-hover').length
+    ).toBe(rowCount);
+    expect(
+      document.querySelectorAll('.option-compact-always.options-injected-action-hover').length
+    ).toBe(0);
   },
 };
 

--- a/src/components/form/engine/compactRowContext.ts
+++ b/src/components/form/engine/compactRowContext.ts
@@ -1,4 +1,5 @@
 import { IReqoreTheme } from '@qoretechnologies/reqore/dist/constants/theme';
+import { IReqorePanelAction } from '@qoretechnologies/reqore/dist/components/Panel';
 import { IReqoreFormTemplates } from '@qoretechnologies/reqore/dist/components/Textarea';
 import { useReqoreProperty } from '@qoretechnologies/reqore';
 import {
@@ -8,7 +9,7 @@ import {
 } from '@qoretechnologies/ts-toolkit';
 import { MutableRefObject } from 'react';
 import { createContext } from 'use-context-selector';
-import { IOperatorsSchema } from './FormEngine';
+import { IOperatorsSchema, TOption } from './FormEngine';
 
 /**
  * The complete closure surface of the (former) `renderCompactRow` function,
@@ -74,6 +75,13 @@ export interface ICompactRowContext {
 
   // Function passed through as a value (stays defined in FormEngine because the
   // classic non-compact path uses it too).
+  optionActions?:
+    | IReqorePanelAction[]
+    | ((context: {
+        name: string;
+        schema: IQorusFormSchema[string];
+        value?: TOption;
+      }) => IReqorePanelAction[]);
   renderOption: (
     optionName: string,
     field: IQorusFormField,

--- a/src/components/form/engine/compactRowContext.ts
+++ b/src/components/form/engine/compactRowContext.ts
@@ -76,6 +76,12 @@ export interface ICompactRowContext {
   // Function passed through as a value (stays defined in FormEngine because the
   // classic non-compact path uses it too).
   optionActions?: TOptionActions;
+  /**
+   * Injected actions render inside the row's overflow menu instead of as inline
+   * buttons. True on touch (where a hover-gated button is unreachable) and on
+   * narrow viewports. Resolved once by FormEngine so rows share one subscription.
+   */
+  collapseOptionActions?: boolean;
   renderOption: (
     optionName: string,
     field: IQorusFormField,

--- a/src/components/form/engine/compactRowContext.ts
+++ b/src/components/form/engine/compactRowContext.ts
@@ -1,5 +1,4 @@
 import { IReqoreTheme } from '@qoretechnologies/reqore/dist/constants/theme';
-import { IReqorePanelAction } from '@qoretechnologies/reqore/dist/components/Panel';
 import { IReqoreFormTemplates } from '@qoretechnologies/reqore/dist/components/Textarea';
 import { useReqoreProperty } from '@qoretechnologies/reqore';
 import {
@@ -9,7 +8,8 @@ import {
 } from '@qoretechnologies/ts-toolkit';
 import { MutableRefObject } from 'react';
 import { createContext } from 'use-context-selector';
-import { IOperatorsSchema, TOption } from './FormEngine';
+import { IOperatorsSchema } from './FormEngine';
+import { TOptionActions } from './optionActions';
 
 /**
  * The complete closure surface of the (former) `renderCompactRow` function,
@@ -75,13 +75,7 @@ export interface ICompactRowContext {
 
   // Function passed through as a value (stays defined in FormEngine because the
   // classic non-compact path uses it too).
-  optionActions?:
-    | IReqorePanelAction[]
-    | ((context: {
-        name: string;
-        schema: IQorusFormSchema[string];
-        value?: TOption;
-      }) => IReqorePanelAction[]);
+  optionActions?: TOptionActions;
   renderOption: (
     optionName: string,
     field: IQorusFormField,

--- a/src/components/form/engine/compactRowStyles.ts
+++ b/src/components/form/engine/compactRowStyles.ts
@@ -82,6 +82,9 @@ export const StyledCompactPanel = styled(ReqorePanel)<{
      don't reflow on hover. */
   .options-injected-action-hover {
     opacity: 0;
+    /* Not hit-testable while invisible — an opacity:0 button still takes taps
+       and clicks, which reads as a mystery control firing out of nowhere. */
+    pointer-events: none;
     transition: opacity 0.15s ease;
   }
   .readfirst-row:hover .options-injected-action-hover,
@@ -89,6 +92,16 @@ export const StyledCompactPanel = styled(ReqorePanel)<{
   .options-readfirst-card:hover .options-injected-action-hover,
   .options-readfirst-card:focus-within .options-injected-action-hover {
     opacity: 1;
+    pointer-events: auto;
+  }
+  /* Touch and other hover-less pointers never fire :hover, so a hover-gated
+     action would be permanently unreachable there. Show it unconditionally
+     instead — losing the tidiness beats losing the functionality. */
+  @media (hover: none), (pointer: coarse) {
+    .options-injected-action-hover {
+      opacity: 1;
+      pointer-events: auto;
+    }
   }
 `;
 

--- a/src/components/form/engine/compactRowStyles.ts
+++ b/src/components/form/engine/compactRowStyles.ts
@@ -73,6 +73,23 @@ export const StyledCompactPanel = styled(ReqorePanel)<{
     flex: 1 1 auto;
     min-width: 0;
   }
+
+  /* An injected option action declared \`show: 'hover'\` — the shape ReqorePanel
+     honours on the classic path — is revealed only while its row or card is
+     hovered or holds focus. The compact slots render plain buttons, so the gate
+     has to be CSS here. Kept focus-visible too, so the action stays reachable by
+     keyboard. Opacity rather than display keeps the slot's width stable, so rows
+     don't reflow on hover. */
+  .options-injected-action-hover {
+    opacity: 0;
+    transition: opacity 0.15s ease;
+  }
+  .readfirst-row:hover .options-injected-action-hover,
+  .readfirst-row:focus-within .options-injected-action-hover,
+  .options-readfirst-card:hover .options-injected-action-hover,
+  .options-readfirst-card:focus-within .options-injected-action-hover {
+    opacity: 1;
+  }
 `;
 
 // Compact group header laid out as the panel's `label`: the group name, a

--- a/src/components/form/engine/optionActions.ts
+++ b/src/components/form/engine/optionActions.ts
@@ -1,0 +1,40 @@
+import { IReqorePanelAction } from '@qoretechnologies/reqore/dist/components/Panel';
+import { IQorusFormField, IQorusFormSchema } from '@qoretechnologies/ts-toolkit';
+
+/**
+ * The context an `optionActions` factory receives for a single option — the
+ * option's name, its schema entry, and its current field value. This is the
+ * IDE's `AiAssistanceAction` context (it injects its `allowAi` button here).
+ */
+export interface IOptionActionsContext {
+  name: string;
+  schema: IQorusFormSchema[string];
+  value?: IQorusFormField;
+}
+
+/**
+ * SEAM (reqraft): per-option injected actions. Either a static list applied to
+ * every option, or a factory invoked once per option with that option's context.
+ */
+export type TOptionActions =
+  | IReqorePanelAction[]
+  | ((context: IOptionActionsContext) => IReqorePanelAction[]);
+
+/**
+ * Resolve the `optionActions` seam for one option.
+ *
+ * Both render paths go through this so a consumer's factory is called with the
+ * same context and its result shaped the same way: the classic path feeds the
+ * result to `ReqorePanel`'s `actions`, the compact path renders the buttons
+ * itself. Falsy entries are dropped so a factory can return conditional actions
+ * inline (`cond && {...}`) without each caller re-filtering.
+ */
+export const resolveOptionActions = (
+  optionActions: TOptionActions | undefined,
+  context: IOptionActionsContext
+): IReqorePanelAction[] => {
+  const actions =
+    typeof optionActions === 'function' ? optionActions(context) : (optionActions ?? []);
+
+  return (actions ?? []).filter((action): action is IReqorePanelAction => !!action);
+};

--- a/src/components/form/engine/readFirst.ts
+++ b/src/components/form/engine/readFirst.ts
@@ -1,4 +1,9 @@
-import { IQorusFormField, TQorusFormFieldSchema } from '@qoretechnologies/ts-toolkit';
+import {
+  IQorusFormField,
+  TQorusFormFieldSchema,
+  TQorusType,
+} from '@qoretechnologies/ts-toolkit';
+import { isRendererOnlyUiType } from './rendererTypes';
 import { isUiEncodedValue } from './_structuredData/structuredData';
 import { renderExpressionToText } from '../expressions/renderExpressionToText';
 import { IExpressionValue } from '../expressions/types';
@@ -223,15 +228,29 @@ export const getFileSize = (value: unknown): number | undefined => {
   return typeof size === 'number' && Number.isFinite(size) && size >= 0 ? size : undefined;
 };
 
-/** Effective UI type for display: the stored `type` wins (any/auto picks),
- * then schema `ui_type`, then `type`. */
+/**
+ * Effective UI type for DISPLAY — which preview/summary a value renders as.
+ *
+ * A renderer-only `ui_type` wins outright: the field's stored `type` holds the
+ * STORAGE type for those (a `code-editor` stores a string), so consulting the
+ * stored type here would render the bespoke editor's value as a plain string and
+ * silently drop its preview. Every other case keeps the stored type first, so an
+ * `any`/`auto` field still displays as whatever concrete type the user picked.
+ */
 export const getValueType = (
   option?: IQorusFormField,
   schema?: TQorusFormFieldSchema
-): string | undefined =>
-  (option?.type ||
-    (schema as { ui_type?: string; type?: string } | undefined)?.ui_type ||
+): string | undefined => {
+  const uiType = (schema as { ui_type?: string } | undefined)?.ui_type;
+
+  if (isRendererOnlyUiType(uiType as TQorusType)) {
+    return uiType;
+  }
+
+  return (option?.type ||
+    uiType ||
     (schema as { type?: string } | undefined)?.type) as string | undefined;
+};
 
 /** Human-readable byte count (e.g. `1.2 KB`). */
 export const formatBytes = (bytes: number): string => {

--- a/src/components/form/engine/rendererTypes.ts
+++ b/src/components/form/engine/rendererTypes.ts
@@ -1,0 +1,55 @@
+import { TQorusType } from '@qoretechnologies/ts-toolkit';
+
+/**
+ * A schema entry carries two type-ish keys with different jobs:
+ *
+ * - `type` names how the value is STORED and validated (`string`, `hash`, `list`…).
+ * - `ui_type` names which EDITOR renders it.
+ *
+ * For most fields `ui_type` is a storage-compatible refinement (`long-string`,
+ * `enum`, `url`) and it is safe to let it win for both jobs. But some `ui_type`s
+ * name a bespoke editor whose value is still stored as the plainer `type` — a
+ * `cron` editor stores a string, `processor-mappings` stores a hash. Writing
+ * those renderer names into the field's `type` breaks validation and round-trips
+ * the value through the wrong branch, which is what `RENDERER_ONLY_UI_TYPES`
+ * exists to prevent.
+ *
+ * There is deliberately no derivation here: a renderer-only `ui_type` is not
+ * distinguishable from a storage-compatible one by inspecting the value or the
+ * `TQorusType` union (`code-editor` and `tool-catalog` are members of it, and
+ * the validator has cases for `cron` and `schema-definition`). It is a fact
+ * about which editor a name selects, so it has to be declared.
+ */
+export const BUILT_IN_RENDERER_ONLY_UI_TYPES: readonly string[] = [
+  'active-windows',
+  'alert-threshold',
+  'code-editor',
+  'cron',
+  'dpql',
+  'processor-mappings',
+  'schema-definition',
+  'test-cases',
+  'test-value-contract',
+  'tool-catalog',
+];
+
+/**
+ * Build the renderer-only predicate for one FormEngine instance.
+ *
+ * Consumers inject their own editors through `componentOverrides`, so the set of
+ * renderer-only names is open-ended — the IDE ships editors reqraft has never
+ * heard of. `extraTypes` (the `rendererOnlyUiTypes` prop) lets a consumer declare
+ * its own without waiting on a reqraft release, which is what previously made
+ * every new IDE editor a silent value-corruption bug until this list caught up.
+ */
+export const createRendererOnlyUiTypeCheck = (
+  extraTypes?: readonly string[]
+): ((type?: TQorusType | TQorusType[]) => boolean) => {
+  const known = new Set<string>([...BUILT_IN_RENDERER_ONLY_UI_TYPES, ...(extraTypes ?? [])]);
+
+  return (type?: TQorusType | TQorusType[]): boolean =>
+    typeof type === 'string' && known.has(type);
+};
+
+/** The default predicate — built-ins only, for module-scope callers with no props. */
+export const isRendererOnlyUiType = createRendererOnlyUiTypeCheck();

--- a/src/components/form/fields/auto/AutoFormField.tsx
+++ b/src/components/form/fields/auto/AutoFormField.tsx
@@ -356,7 +356,12 @@ function AutoField<T = any>({
         {...rest}
         name={name}
         value={value}
-        onChange={(val: any) => handleChange(name, val)}
+        onChange={(val: any, emittedType?: IQorusType, emittedIsFunction?: boolean) => {
+          const returnType = emittedType || currentType;
+          if (onChange && returnType) {
+            onChange(name, val, returnType, emittedIsFunction);
+          }
+        }}
       />
     );
   }

--- a/src/components/form/index.tsx
+++ b/src/components/form/index.tsx
@@ -22,6 +22,8 @@ export * from './fields/select/SelectCollection';
 export * from './fields/string/String';
 export * from './fields/template/TemplateField';
 export * from './engine/FormEngine';
+export * from './engine/optionActions';
+export * from './engine/rendererTypes';
 export * from './expressions/types';
 export * from './expressions/useExpressions';
 // Named (not wildcard) so the `_resetRenderExpressionTransportForTests`

--- a/src/hooks/useMediaQuery.ts
+++ b/src/hooks/useMediaQuery.ts
@@ -1,0 +1,61 @@
+import { useEffect, useState } from 'react';
+
+/**
+ * Subscribe to a CSS media query.
+ *
+ * Exists because some affordances cannot be expressed in CSS alone: a
+ * hover-gated control has to MOVE into an overflow menu on a device that has no
+ * hover, and moving a node is a React decision, not a stylesheet one.
+ *
+ * SSR/JSDOM-safe: environments without `matchMedia` report `false` rather than
+ * throwing, so a server render (or a unit test) behaves as if the query does not
+ * match instead of crashing.
+ */
+export const useMediaQuery = (query: string): boolean => {
+  const [matches, setMatches] = useState<boolean>(() => {
+    if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+      return false;
+    }
+
+    return window.matchMedia(query).matches;
+  });
+
+  useEffect(() => {
+    if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+      return undefined;
+    }
+
+    const list = window.matchMedia(query);
+    const onChange = (event: MediaQueryListEvent) => setMatches(event.matches);
+
+    // Re-read on subscribe: the query can have changed between the initial
+    // render and this effect (a resize during hydration).
+    setMatches(list.matches);
+
+    // Safari <14 only has the deprecated add/removeListener pair.
+    if (typeof list.addEventListener === 'function') {
+      list.addEventListener('change', onChange);
+      return () => list.removeEventListener('change', onChange);
+    }
+
+    list.addListener(onChange);
+    return () => list.removeListener(onChange);
+  }, [query]);
+
+  return matches;
+};
+
+/** A pointer that can hover (a mouse), as opposed to touch. */
+export const HOVER_CAPABLE_QUERY = '(hover: hover) and (pointer: fine)';
+
+/** Viewport narrow enough that per-row action buttons stop fitting. */
+export const NARROW_VIEWPORT_QUERY = '(max-width: 768px)';
+
+/**
+ * Whether hover-revealed affordances are usable here. `false` on touch, where
+ * :hover never fires and a hover-gated control would be unreachable.
+ */
+export const useCanHover = (): boolean => useMediaQuery(HOVER_CAPABLE_QUERY);
+
+/** Whether the viewport is narrow enough to collapse per-row actions. */
+export const useIsNarrowViewport = (): boolean => useMediaQuery(NARROW_VIEWPORT_QUERY);

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -21,6 +21,13 @@ export type {
 export { useFetch } from './hooks/useFetch/useFetch';
 export type { IReqraftUseFetch } from './hooks/useFetch/useFetch';
 export { useReqraftStorage } from './hooks/useStorage/useStorage';
+export {
+  useCanHover,
+  useIsNarrowViewport,
+  useMediaQuery,
+  HOVER_CAPABLE_QUERY,
+  NARROW_VIEWPORT_QUERY,
+} from './hooks/useMediaQuery';
 export type { TReqraftUseStorage } from './hooks/useStorage/useStorage';
 export * from './hooks/useWebSocket/useWebSocket';
 export {


### PR DESCRIPTION
Follow-up to #83 on the same branch (that PR is merged; issue #82 is closed).

## What this does

`ui_type` names which **editor** renders a field; `type` names how the value is
**stored**. The engine conflated the two. Separating them cleanly is the whole
PR, and most of the bugs below came from getting the split half-right.

| Commit | |
|---|---|
| `d1a95a0` | Resolve an option's storage type from the schema's `type` when `ui_type` only names a renderer. Adds the `optionActions` seam to the compact path. |
| `3e843f4` | Display paths must read the renderer type; class-level cleanups. |
| `17f56ef` | Version bump to `0.10.17`. |
| `14e4866` | Fold in the overlapping work from `bugfix/form-engine-undefined-type`. |
| `ec2fec6` | Editor picked from the renderer type; hover actions reachable on touch. |

## The storage / renderer split

- **Storage type** — what the value is saved and validated as. Governed by the
  renderer-only list in `rendererTypes.ts`. A `cron` editor stores a string.
- **Renderer type** — which editor mounts. Governed by `resolvedType` in
  `renderOption`: `ui_type` wins, **except** when it is any-like (`any`/`auto`),
  where the schema deliberately defers to the concrete type the user picked.

Keeping those two rules in separate places is load-bearing. `richtext` is
deliberately *not* in the renderer-only list — its value really is stored as the
schema's string — but it must still *render* as richtext. Conflating them broke
`Compact Basic`; getting the render precedence wrong broke `Option With Any Type`.

## Bugs fixed (each caught by capturing the story and reading the pixels)

1. **Renderer-only fields lost their preview.** `getValueType` drives display but
   read the stored type first, so the compact code block stopped mounting and the
   value cell fell back to a truncated raw string.
2. **The file option's card rendered empty.** The editor was chosen from the
   storage type, so a `richtext` field mounted a plain string input — resizing its
   card, reflowing the collection, and pushing the neighbouring file card out of
   view. Verified against `develop` in an isolated worktree.
3. **`op` and other envelope keys were dropped.** `fixOptions` rebuilt untyped
   fields as bare `{type, value}`. It now spreads the original envelope.
4. **Missing schema crashed the render.** `getType` / `getTypeAndCanBeNull`
   tolerate an undefined type; `fixOptions` returns the value verbatim until its
   schema arrives.
5. **Hover-only actions were unreachable on touch.** A `show: 'hover'` action
   never appeared on a device with no hover, and — being only `opacity: 0` — still
   absorbed taps as an invisible target. Now `pointer-events: none` while hidden
   and shown unconditionally under `(hover: none)` / `(pointer: coarse)`.
6. **`show` behaved differently per path.** The compact path stripped it; it is
   now a CSS gate, so one factory behaves the same in both modes.

## Class-level changes

- **`RENDERER_ONLY_UI_TYPES` is no longer hardcoded inside `FormEngine`.** It moves
  to `rendererTypes.ts` with the invariant documented, and becomes extensible via a
  new **`rendererOnlyUiTypes`** prop — consumers inject their own editors through
  `componentOverrides`, so the set is open-ended. Previously each new IDE editor was
  a silent value-corruption bug until reqraft shipped a release naming it. There is
  deliberately no derivation: `code-editor` and `tool-catalog` are members of
  `TQorusType`, and the validator has cases for `cron` and `schema-definition`.
- **`optionActions` resolution was duplicated** across both paths; both now call one
  `resolveOptionActions`.

## Tests

| Gate | Result |
|---|---|
| `yarn lint` / `build:test:prod` | clean |
| `yarn test` | 20 files, **495 passed** (17 new) |
| `yarn test:stories` (CI) | **36 files passed** |
| Qlip build 56 | 0 changed, 324 unchanged — the build-54 regression is gone |

## Known follow-up: `useMediaQuery` moves to Reqore

This PR adds a local `src/hooks/useMediaQuery.ts`. That is a **generic** primitive,
so by the Reqore-first rule it belongs in Reqore, not here — it lives here only to
avoid blocking this PR on a cross-repo release.

The Reqore side is already open: **qoretechnologies/reqore#620** adds
`isHoverCapable` to the Reqore context (pointer capability, distinct from the
existing width-based `isMobile`/`isTablet`).

Once that merges and publishes **`@qoretechnologies/reqore@0.71.14`** to npm, a
follow-up here drops the local hook and reads the capability from the context
instead:

```tsx
const isHoverCapable = useReqoreProperty('isHoverCapable');
```

Deliberately sequenced after the npm publish rather than pinned to an unreleased
version. Flagging it so the duplicate primitive is a recorded decision rather than
something an audit finds later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
