### PR TITLE
fix(form-engine): auto-close fixed choices in compact forms

### DIFF
--- a/__tests__/readFirst.test.ts
+++ b/__tests__/readFirst.test.ts
@@ -21,6 +21,7 @@ import {
   getReadFirstCompletion,
   getReadFirstStatus,
   isOptionValueEmpty,
+  shouldAutoCollapseCompactAllowedValueOption,
   type IFirstAttentionFieldMeta,
 } from '../src/components/form/engine/readFirst';
 
@@ -37,6 +38,39 @@ describe('isOptionValueEmpty', () => {
     expect(isOptionValueEmpty(false)).toBe(false);
     expect(isOptionValueEmpty('x')).toBe(false);
     expect(isOptionValueEmpty(['a'])).toBe(false);
+  });
+});
+
+describe('shouldAutoCollapseCompactAllowedValueOption', () => {
+  const fixedChoiceSchema = {
+    type: 'string',
+    allowed_values: [{ value: 'api', display_name: 'API' }],
+  } as never;
+
+  it('auto-collapses fixed allowed-value selections', () => {
+    expect(shouldAutoCollapseCompactAllowedValueOption(fixedChoiceSchema, 'api')).toBe(true);
+  });
+
+  it('does not auto-collapse empty values', () => {
+    expect(shouldAutoCollapseCompactAllowedValueOption(fixedChoiceSchema, '')).toBe(false);
+  });
+
+  it('does not auto-collapse creatable allowed-value fields', () => {
+    expect(
+      shouldAutoCollapseCompactAllowedValueOption(
+        { ...fixedChoiceSchema, allowed_values_creatable: true } as never,
+        'custom'
+      )
+    ).toBe(false);
+  });
+
+  it('does not auto-collapse multiselect fields', () => {
+    expect(
+      shouldAutoCollapseCompactAllowedValueOption(
+        { ...fixedChoiceSchema, multiselect: true } as never,
+        ['api']
+      )
+    ).toBe(false);
   });
 });
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qoretechnologies/reqraft",
-  "version": "0.10.18",
+  "version": "0.10.19",
   "description": "ReQraft is a collection of React components and hooks that are used across Qore Technologies' products made using the ReQore component library from Qore.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/components/form/engine/FormEngine.tsx
+++ b/src/components/form/engine/FormEngine.tsx
@@ -101,6 +101,7 @@ import {
   getReadFirstCompletion,
   getReadFirstStatus,
   isOptionValueEmpty,
+  shouldAutoCollapseCompactAllowedValueOption,
 } from './readFirst';
 
 // Re-export types for consumers
@@ -1157,6 +1158,14 @@ export const FormEngine = ({
 
         onSingleOptionsChange?.(optionName, updatedValue[optionName]);
 
+        if (
+          compact &&
+          !readOnly &&
+          shouldAutoCollapseCompactAllowedValueOption(options?.[optionName], val)
+        ) {
+          setExpandedOptions((prev) => prev.filter((name) => name !== optionName));
+        }
+
         return {
           fields: updatedValue,
           meta,
@@ -1167,6 +1176,8 @@ export const FormEngine = ({
       onSingleOptionsChange,
       onDependableOptionChange,
       isRendererOnly,
+      compact,
+      readOnly,
       JSON.stringify(options),
       JSON.stringify(operators),
     ]

--- a/src/components/form/engine/readFirst.ts
+++ b/src/components/form/engine/readFirst.ts
@@ -87,6 +87,27 @@ export const isOptionValueEmpty = (value: unknown): boolean =>
   value === '' ||
   (Array.isArray(value) && value.length === 0);
 
+export const shouldAutoCollapseCompactAllowedValueOption = (
+  schema: TQorusFormFieldSchema | undefined,
+  value: unknown
+): boolean => {
+  if (!schema || isOptionValueEmpty(value)) {
+    return false;
+  }
+
+  const selectableSchema = schema as TQorusFormFieldSchema & { items?: unknown[] };
+  const options = selectableSchema.allowed_values?.length
+    ? selectableSchema.allowed_values
+    : selectableSchema.items;
+
+  return !!(
+    options?.length &&
+    !schema.allowed_values_creatable &&
+    !schema.multiselect &&
+    !schema.arg_schema
+  );
+};
+
 /** Prefer the matching allowed_values entry's display_name (fallback `name`)
  * over the raw stored value. */
 const findAllowedOption = (value: unknown, schema?: TQorusFormFieldSchema): any | undefined => {


### PR DESCRIPTION
## Summary\n- Auto-collapse compact read-first fields after selecting a fixed allowed value.\n- Preserve explicit confirmation for empty values, creatable allowed values, multiselect fields, and structured arg_schema fields.\n- Bump @qoretechnologies/reqraft to 0.10.19 for the develop beta publish workflow.\n\n## Validation\n- yarn precheck\n- push-time pre-push hook: lint + unit tests\n\n## Audit\n- Applied the shared frontend audit baseline from ~/Projects/instruction-files/skills/audit-frontend/SKILL.md. No hard stops, no visual/story changes, no Reqore/Reqraft compliance issues.