### PR TITLE
fix(form-engine): complete fixed choice interactions and honour forceDropdown={false}

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -3,6 +3,37 @@ import { ReqoreContent, ReqoreLayoutContent, ReqoreUIProvider } from '@qoretechn
 import { initializeReqraft } from '../src';
 import { fetchConfig } from '../src/utils/fetch';
 
+// TEMPORARY CI DIAGNOSTIC — remove once `Option With Any Type` is understood.
+// The story fails only in CI (green locally, and unreproducible here because no
+// available token authenticates against hq). Surface what actually tears the
+// preview down so the CI log names the cause instead of a downstream timeout.
+if (typeof window !== 'undefined' && !(window as any).__ciDiag) {
+  (window as any).__ciDiag = true;
+  window.addEventListener('unhandledrejection', (e: any) => {
+    const r = e?.reason;
+    // eslint-disable-next-line no-console
+    console.error(
+      'CI_DIAG unhandledrejection >>>',
+      'type=', typeof r,
+      'ctor=', r?.constructor?.name,
+      'msg=', String(r?.message ?? r),
+      'json=', (() => { try { return JSON.stringify(r); } catch { return '<unserializable>'; } })(),
+      'stack=', String(r?.stack ?? 'none')
+    );
+  });
+  window.addEventListener('error', (e: any) => {
+    // eslint-disable-next-line no-console
+    console.error('CI_DIAG error >>>', String(e?.message), 'stack=', String(e?.error?.stack ?? 'none'));
+  });
+  // The 401→redirect recursion documented below is the prime suspect: if the
+  // preview navigates away, say so — that is what replaces the canvas with the
+  // Storybook manager and produces the "No Preview" screen.
+  window.addEventListener('beforeunload', () => {
+    // eslint-disable-next-line no-console
+    console.error('CI_DIAG preview navigating away >>> href=', String(window.location.href));
+  });
+}
+
 export const parameters = {
   // No `actions.argTypesRegex` (removed in SB10): stories that assert on
   // handlers define explicit `fn()` spies from `storybook/test` instead.

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -3,37 +3,6 @@ import { ReqoreContent, ReqoreLayoutContent, ReqoreUIProvider } from '@qoretechn
 import { initializeReqraft } from '../src';
 import { fetchConfig } from '../src/utils/fetch';
 
-// TEMPORARY CI DIAGNOSTIC — remove once `Option With Any Type` is understood.
-// The story fails only in CI (green locally, and unreproducible here because no
-// available token authenticates against hq). Surface what actually tears the
-// preview down so the CI log names the cause instead of a downstream timeout.
-if (typeof window !== 'undefined' && !(window as any).__ciDiag) {
-  (window as any).__ciDiag = true;
-  window.addEventListener('unhandledrejection', (e: any) => {
-    const r = e?.reason;
-    // eslint-disable-next-line no-console
-    console.error(
-      'CI_DIAG unhandledrejection >>>',
-      'type=', typeof r,
-      'ctor=', r?.constructor?.name,
-      'msg=', String(r?.message ?? r),
-      'json=', (() => { try { return JSON.stringify(r); } catch { return '<unserializable>'; } })(),
-      'stack=', String(r?.stack ?? 'none')
-    );
-  });
-  window.addEventListener('error', (e: any) => {
-    // eslint-disable-next-line no-console
-    console.error('CI_DIAG error >>>', String(e?.message), 'stack=', String(e?.error?.stack ?? 'none'));
-  });
-  // The 401→redirect recursion documented below is the prime suspect: if the
-  // preview navigates away, say so — that is what replaces the canvas with the
-  // Storybook manager and produces the "No Preview" screen.
-  window.addEventListener('beforeunload', () => {
-    // eslint-disable-next-line no-console
-    console.error('CI_DIAG preview navigating away >>> href=', String(window.location.href));
-  });
-}
-
 export const parameters = {
   // No `actions.argTypesRegex` (removed in SB10): stories that assert on
   // handlers define explicit `fn()` spies from `storybook/test` instead.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+.claude/CLAUDE.md

--- a/__tests__/formEngineAllowedValues.test.tsx
+++ b/__tests__/formEngineAllowedValues.test.tsx
@@ -1,0 +1,243 @@
+import { ReqoreUIProvider } from '@qoretechnologies/reqore';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import { FetchContext } from '../src/contexts/FetchContext';
+import { FormEngine } from '../src/components/form/engine/FormEngine';
+
+const fetchContext = {
+  get: vi.fn(async () => ({ ok: true, data: [] })),
+  post: vi.fn(async () => ({ ok: true, data: [] })),
+  put: vi.fn(async () => ({ ok: true, data: [] })),
+  del: vi.fn(async () => ({ ok: true, data: [] })),
+};
+
+describe('FormEngine fixed allowed-value fields', () => {
+  it('renders a selectable editor for fixed allowed values with a rich renderer hint', async () => {
+    render(
+      <ReqoreUIProvider>
+        <FetchContext.Provider value={fetchContext}>
+          <FormEngine
+            compact
+            name='delivery'
+            value={{}}
+            options={{
+              guild: {
+                type: 'string',
+                ui_type: 'string',
+                display_name: 'Server',
+                required: true,
+                allowed_values_creatable: false,
+                supports_custom_values: false,
+                supports_expressions: false,
+                supports_templates: false,
+                disallow_template: true,
+                allowed_values: [
+                  {
+                    display_name: 'Qore Technologies',
+                    desc: 'Discord guild used for alert notifications.',
+                    value: { type: 'string', value: 'Qore Technologies' },
+                  },
+                  {
+                    display_name: 'Developer Ecosystem',
+                    value: { type: 'string', value: 'Developer Ecosystem' },
+                  },
+                  {
+                    display_name: 'Portal 2: CE',
+                    value: { type: 'string', value: 'Portal 2: CE' },
+                  },
+                  {
+                    display_name: 'Invest in Bravery',
+                    value: { type: 'string', value: 'Invest in Bravery' },
+                  },
+                ],
+              },
+            }}
+            forceDropdown
+            templateFieldProps={{ forceDropdown: true }}
+            initialExpandedOptions={['guild']}
+          />
+        </FetchContext.Provider>
+      </ReqoreUIProvider>
+    );
+
+    expect((await screen.findAllByText('Please select')).length).toBeGreaterThan(0);
+    expect(screen.getAllByText('4').length).toBeGreaterThan(0);
+  });
+
+  it('keeps compact booleans unset until chosen and auto-collapses either choice', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    const { container } = render(
+      <ReqoreUIProvider>
+        <FetchContext.Provider value={fetchContext}>
+          <FormEngine
+            compact
+            name='settings'
+            value={{}}
+            options={{
+              enabled: {
+                type: 'bool',
+                ui_type: 'bool',
+                display_name: 'Enabled',
+                required: true,
+              },
+            }}
+            initialExpandedOptions={['enabled']}
+            onChange={onChange}
+          />
+        </FetchContext.Provider>
+      </ReqoreUIProvider>
+    );
+
+    const switchElement = (await screen.findByText('Yes')).closest('[tabindex="0"]');
+    expect(switchElement).toBeTruthy();
+    expect(container.querySelector('[data-field="enabled"].readfirst-row-editing')).toBeTruthy();
+
+    await user.click(switchElement as HTMLElement);
+
+    expect(onChange).toHaveBeenCalledWith(
+      'settings',
+      expect.objectContaining({
+        enabled: expect.objectContaining({ type: 'bool', value: true }),
+      }),
+      undefined
+    );
+    expect(container.querySelector('[data-field="enabled"].readfirst-row-editing')).toBeNull();
+  });
+
+  it('emits fixed allowed-value selections immediately without the row confirmation button', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    const onDependableOptionChange = vi.fn();
+
+    render(
+      <ReqoreUIProvider>
+        <FetchContext.Provider value={fetchContext}>
+          <FormEngine
+            compact
+            name='delivery'
+            value={{}}
+            options={{
+              guild: {
+                type: 'string',
+                ui_type: 'string',
+                display_name: 'Server',
+                required: true,
+                has_dependents: true,
+                allowed_values_creatable: false,
+                supports_custom_values: false,
+                supports_expressions: false,
+                supports_templates: false,
+                disallow_template: true,
+                allowed_values: [
+                  {
+                    display_name: 'Qore Technologies',
+                    desc: 'Discord guild "Qore Technologies"',
+                    value: { type: 'string', value: 'Qore Technologies' },
+                  },
+                  {
+                    display_name: 'Developer Ecosystem (devEco)',
+                    desc: 'Discord guild "Developer Ecosystem (devEco)"',
+                    value: { type: 'string', value: 'Developer Ecosystem (devEco)' },
+                  },
+                ],
+              },
+              channel: {
+                type: 'string',
+                ui_type: 'string',
+                display_name: 'Channel',
+                depends_on: ['guild'],
+              },
+            }}
+            forceDropdown
+            templateFieldProps={{ forceDropdown: true }}
+            initialExpandedOptions={['guild']}
+            onChange={onChange}
+            onDependableOptionChange={onDependableOptionChange}
+          />
+        </FetchContext.Provider>
+      </ReqoreUIProvider>
+    );
+
+    await user.click(await screen.findByText('Qore Technologies'));
+
+    expect(screen.queryByRole('button', { name: /done|check/i })).toBeNull();
+    expect(onDependableOptionChange).toHaveBeenCalledWith(
+      'guild',
+      'Qore Technologies',
+      expect.objectContaining({
+        guild: expect.objectContaining({
+          type: 'string',
+          value: 'Qore Technologies',
+        }),
+      }),
+      expect.any(Object)
+    );
+    expect(onChange).toHaveBeenCalledWith(
+      'delivery',
+      expect.objectContaining({
+        guild: expect.objectContaining({
+          type: 'string',
+          value: 'Qore Technologies',
+        }),
+      }),
+      undefined
+    );
+  });
+
+  it('allows fixed allowed-value editors to close without selecting or clearing a value', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    const onDependableOptionChange = vi.fn();
+
+    render(
+      <ReqoreUIProvider>
+        <FetchContext.Provider value={fetchContext}>
+          <FormEngine
+            compact
+            name='delivery'
+            value={{}}
+            options={{
+              guild: {
+                type: 'string',
+                ui_type: 'string',
+                display_name: 'Server',
+                required: true,
+                has_dependents: true,
+                allowed_values_creatable: false,
+                allowed_values: [
+                  {
+                    display_name: 'Qore Technologies',
+                    desc: 'Discord guild "Qore Technologies"',
+                    value: { type: 'string', value: 'Qore Technologies' },
+                  },
+                  {
+                    display_name: 'Developer Ecosystem (devEco)',
+                    desc: 'Discord guild "Developer Ecosystem (devEco)"',
+                    value: { type: 'string', value: 'Developer Ecosystem (devEco)' },
+                  },
+                ],
+              },
+            }}
+            forceDropdown
+            templateFieldProps={{ forceDropdown: true }}
+            initialExpandedOptions={['guild']}
+            onChange={onChange}
+            onDependableOptionChange={onDependableOptionChange}
+          />
+        </FetchContext.Provider>
+      </ReqoreUIProvider>
+    );
+
+    expect(await screen.findByText('Qore Technologies')).toBeTruthy();
+    onChange.mockClear();
+    onDependableOptionChange.mockClear();
+
+    await user.click(screen.getByRole('button', { name: /close field/i }));
+
+    expect(screen.queryByText('Qore Technologies')).toBeNull();
+    expect(onChange).not.toHaveBeenCalled();
+    expect(onDependableOptionChange).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/formEngineOptions.test.ts
+++ b/__tests__/formEngineOptions.test.ts
@@ -80,6 +80,26 @@ describe('fixOptions', () => {
     expect(fixed.schedule).toEqual({ type: 'string', value: '0 0 * * *' });
   });
 
+  it('stores fixed allowed-value selectors under the storage type even with a rich renderer hint', () => {
+    const fixed = fixOptions(
+      { server: { value: 'Qore Technologies' } } as never,
+      {
+        server: {
+          type: 'string',
+          ui_type: 'richtext',
+          allowed_values: [
+            {
+              display_name: 'Qore Technologies',
+              value: { type: 'string', value: 'Qore Technologies' },
+            },
+          ],
+        },
+      } as never
+    );
+
+    expect(fixed.server).toEqual({ type: 'string', value: 'Qore Technologies' });
+  });
+
   it('lets a storage-compatible ui_type win over the schema type', () => {
     const fixed = fixOptions(
       { note: { value: 'hello' } } as never,

--- a/__tests__/readFirst.test.ts
+++ b/__tests__/readFirst.test.ts
@@ -21,7 +21,9 @@ import {
   getReadFirstCompletion,
   getReadFirstStatus,
   isFixedCompactAllowedValueOption,
+  isCompactBooleanOption,
   isOptionValueEmpty,
+  shouldAutoCollapseCompactOption,
   shouldAutoCollapseCompactAllowedValueOption,
   type IFirstAttentionFieldMeta,
 } from '../src/components/form/engine/readFirst';
@@ -85,6 +87,22 @@ describe('shouldAutoCollapseCompactAllowedValueOption', () => {
         ['api']
       )
     ).toBe(false);
+  });
+});
+
+describe('shouldAutoCollapseCompactOption', () => {
+  it('identifies both supported boolean schema names', () => {
+    expect(isCompactBooleanOption({ type: 'bool' } as never)).toBe(true);
+    expect(isCompactBooleanOption({ ui_type: 'boolean' } as never)).toBe(true);
+    expect(isCompactBooleanOption({ type: 'string' } as never)).toBe(false);
+  });
+
+  it('auto-collapses explicit true and false choices but not an unset boolean', () => {
+    const schema = { type: 'bool', ui_type: 'bool' } as never;
+
+    expect(shouldAutoCollapseCompactOption(schema, true)).toBe(true);
+    expect(shouldAutoCollapseCompactOption(schema, false)).toBe(true);
+    expect(shouldAutoCollapseCompactOption(schema, undefined)).toBe(false);
   });
 });
 

--- a/__tests__/readFirst.test.ts
+++ b/__tests__/readFirst.test.ts
@@ -20,6 +20,7 @@ import {
   getReadFirstBucket,
   getReadFirstCompletion,
   getReadFirstStatus,
+  isFixedCompactAllowedValueOption,
   isOptionValueEmpty,
   shouldAutoCollapseCompactAllowedValueOption,
   type IFirstAttentionFieldMeta,
@@ -46,6 +47,19 @@ describe('shouldAutoCollapseCompactAllowedValueOption', () => {
     type: 'string',
     allowed_values: [{ value: 'api', display_name: 'API' }],
   } as never;
+
+  it('identifies fixed allowed-value fields that do not need a Done confirmation', () => {
+    expect(isFixedCompactAllowedValueOption(fixedChoiceSchema)).toBe(true);
+    expect(
+      isFixedCompactAllowedValueOption({
+        ...fixedChoiceSchema,
+        allowed_values_creatable: true,
+      } as never)
+    ).toBe(false);
+    expect(
+      isFixedCompactAllowedValueOption({ ...fixedChoiceSchema, arg_schema: {} } as never)
+    ).toBe(false);
+  });
 
   it('auto-collapses fixed allowed-value selections', () => {
     expect(shouldAutoCollapseCompactAllowedValueOption(fixedChoiceSchema, 'api')).toBe(true);

--- a/__tests__/selectCollection.test.ts
+++ b/__tests__/selectCollection.test.ts
@@ -1,0 +1,29 @@
+import { getSelectItemDescription } from '../src/components/form/fields/select/SelectCollection';
+
+describe('SelectFieldCollection descriptions', () => {
+  it('uses the long description instead of rendering short and long descriptions together', () => {
+    expect(
+      getSelectItemDescription({
+        short_desc: 'Discord guild "Qore Technologies"',
+        desc: 'Discord guild "Qore Technologies"',
+      })
+    ).toBe('Discord guild "Qore Technologies"');
+  });
+
+  it('falls back to the short description when no long description is present', () => {
+    expect(
+      getSelectItemDescription({
+        short_desc: 'Discord guild "Qore Technologies"',
+      })
+    ).toBe('Discord guild "Qore Technologies"');
+  });
+
+  it('ignores blank descriptions', () => {
+    expect(
+      getSelectItemDescription({
+        short_desc: '  ',
+        desc: '',
+      })
+    ).toBeUndefined();
+  });
+});

--- a/__tests__/selectCollection.test.ts
+++ b/__tests__/selectCollection.test.ts
@@ -1,4 +1,8 @@
-import { getSelectItemDescription } from '../src/components/form/fields/select/SelectCollection';
+import {
+  getSelectItemDescription,
+  getSelectItemDescriptionProps,
+  getSelectItemShortDescription,
+} from '../src/components/form/fields/select/SelectCollection';
 
 describe('SelectFieldCollection descriptions', () => {
   it('uses the long description instead of rendering short and long descriptions together', () => {
@@ -25,5 +29,46 @@ describe('SelectFieldCollection descriptions', () => {
         desc: '',
       })
     ).toBeUndefined();
+  });
+
+  it('uses only the plain short description in dropdowns', () => {
+    const item = {
+      short_desc: 'Short Discord server summary',
+      desc: '**Full** Discord server description',
+    };
+
+    expect(getSelectItemShortDescription(item, 'Fallback')).toBe('Short Discord server summary');
+  });
+
+  it('uses the caller fallback only when the item has no description', () => {
+    expect(getSelectItemShortDescription(undefined, 'Pick a server')).toBe('Pick a server');
+    expect(getSelectItemShortDescription({ short_desc: '', desc: '  ' }, 'Pick a server')).toBe(
+      'Pick a server'
+    );
+  });
+
+  it('deduplicates repeated lines inside the effective description', () => {
+    expect(
+      getSelectItemDescription({
+        desc: 'Discord guild "Qore Technologies"\nDiscord guild "Qore Technologies"',
+      })
+    ).toBe('Discord guild "Qore Technologies"');
+  });
+
+  it('exposes only the markdown long description to collection views', () => {
+    expect(
+      getSelectItemDescriptionProps({
+        short_desc: 'Short Discord server summary',
+        desc: '**Full** Discord server description',
+      })
+    ).toEqual({ longDescription: '**Full** Discord server description' });
+  });
+
+  it('falls back to one plain short description in collection views', () => {
+    expect(
+      getSelectItemDescriptionProps({
+        short_desc: 'Short Discord server summary',
+      })
+    ).toEqual({ shortDescription: 'Short Discord server summary' });
   });
 });

--- a/__tests__/selectField.test.tsx
+++ b/__tests__/selectField.test.tsx
@@ -1,4 +1,5 @@
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { useState } from 'react';
 import { vi } from 'vitest';
 
 vi.mock('@qoretechnologies/reqore', () => ({
@@ -70,5 +71,33 @@ describe('SelectFormField', () => {
     fireEvent.click(screen.getByTestId('reqore-button'));
 
     expect(screen.getByTestId('select-modal')).toBeTruthy();
+  });
+
+  it('auto-selects a sole value after render without updating its parent during render', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+    const ControlledSelect = () => {
+      const [value, setValue] = useState<unknown>();
+
+      return (
+        <SelectFormField
+          autoSelect
+          items={[{ display_name: 'Only choice', value: 'only' }]}
+          value={value}
+          onChange={setValue}
+        />
+      );
+    };
+
+    render(<ControlledSelect />);
+
+    await waitFor(() =>
+      expect(screen.getByTestId('reqore-button').textContent).toBe('Only choice')
+    );
+    const loggedErrors = consoleError.mock.calls.flat().join('\n');
+    expect(loggedErrors).not.toContain('Cannot update a component');
+    expect(loggedErrors).not.toContain('Too many re-renders');
+
+    consoleError.mockRestore();
   });
 });

--- a/__tests__/selectField.test.tsx
+++ b/__tests__/selectField.test.tsx
@@ -1,0 +1,74 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { vi } from 'vitest';
+
+vi.mock('@qoretechnologies/reqore', () => ({
+  ReqoreButton: ({ children, label, onClick, description, ...rest }: any) => (
+    <button
+      type='button'
+      onClick={onClick}
+      data-testid='reqore-button'
+      data-description={description}
+      {...rest}
+    >
+      {children ?? label}
+    </button>
+  ),
+  ReqoreCollection: ({ items }: any) => (
+    <div data-testid='select-collection'>
+      {items.map((item: any) => (
+        <button type='button' key={item.label} onClick={item.onClick}>
+          {item.label}
+          {item.content}
+        </button>
+      ))}
+    </div>
+  ),
+  ReqoreControlGroup: ({ children }: any) => <div>{children}</div>,
+  ReqoreDropdown: ({ children, items }: any) => (
+    <div data-testid='select-dropdown' data-items={items.length}>
+      {children}
+    </div>
+  ),
+  ReqoreMenu: ({ children }: any) => <div>{children}</div>,
+  ReqoreMenuItem: ({ label, onClick }: any) => (
+    <button type='button' onClick={onClick}>
+      {label}
+    </button>
+  ),
+  ReqoreMessage: ({ children }: any) => <div>{children}</div>,
+  ReqoreModal: ({ children, isOpen }: any) =>
+    isOpen ? <div data-testid='select-modal'>{children}</div> : null,
+  ReqoreP: ({ children }: any) => <p>{children}</p>,
+  ReqoreTag: ({ label }: any) => <span>{label}</span>,
+}));
+
+vi.mock('../src/components/Description', () => ({
+  Description: ({ longDescription, shortDescription }: any) => (
+    <p>{longDescription || shortDescription}</p>
+  ),
+}));
+
+import { SelectFormField } from '../src/components/form/fields/select/Select';
+
+describe('SelectFormField', () => {
+  const describedItem = {
+    display_name: 'Qore Technologies',
+    value: 'qore-technologies',
+    desc: 'Discord guild "Qore Technologies"',
+  };
+
+  it('uses the inline dropdown for described values by default', () => {
+    render(<SelectFormField items={[describedItem]} />);
+
+    expect(screen.getByTestId('select-dropdown')).toBeTruthy();
+    expect(screen.queryByTestId('select-modal')).toBeNull();
+  });
+
+  it('opens the collection modal only when forceDropdown is explicitly disabled', () => {
+    render(<SelectFormField items={[describedItem]} forceDropdown={false} />);
+
+    fireEvent.click(screen.getByTestId('reqore-button'));
+
+    expect(screen.getByTestId('select-modal')).toBeTruthy();
+  });
+});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qoretechnologies/reqraft",
-  "version": "0.10.19",
+  "version": "0.10.20",
   "description": "ReQraft is a collection of React components and hooks that are used across Qore Technologies' products made using the ReQore component library from Qore.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "@chromatic-com/storybook": "^5.2.1",
     "@netsells/storybook-mockdate": "^0.3.3",
     "@qoretechnologies/qlip": "^0.1.3-beta.20260724071501",
-    "@qoretechnologies/reqore": "^0.71.14",
+    "@qoretechnologies/reqore": "^0.71.16",
     "@storybook/addon-docs": "^10.4.6",
     "@storybook/addon-links": "^10.4.6",
     "@storybook/addon-vitest": "^10.4.6",
@@ -99,7 +99,7 @@
     "vitest": "^4.1.8"
   },
   "peerDependencies": {
-    "@qoretechnologies/reqore": ">=0.71.14",
+    "@qoretechnologies/reqore": ">=0.71.16",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"
   },

--- a/src/components/form/engine/CompactRow.tsx
+++ b/src/components/form/engine/CompactRow.tsx
@@ -578,8 +578,9 @@ export const CompactRow = memo(
     // — distinct from the read-row "Remove field" (which deletes an optional
     // field entirely). Once cleared, `changed` flips on and `hasValue` off, so
     // this button gives way to `revertButton` in the same slot — the morph the
-    // edit row's actions are designed around. Neutral (not danger): it's a
-    // reversible step, undone by Revert or by re-typing.
+    // edit row's actions are designed around. Clearing is destructive even
+    // though it can be reverted before saving, so both the trigger and its
+    // confirmation use danger intent.
     //
     // Only editors with NO built-in clear of their own get this button —
     // toggles and fixed-choice pickers. The text/number/date inputs already
@@ -592,6 +593,17 @@ export const CompactRow = memo(
       // CREATABLE one still renders the raw input (with its own ✕), so it keeps
       // its clear — matching the dispatch in AutoFormField/TemplateField.
       (!!size(schema?.allowed_values) && !schema?.allowed_values_creatable);
+    const confirmClearValue = (event?: React.MouseEvent) => {
+      event?.stopPropagation();
+      confirmAction({
+        title: 'Clear value',
+        description: `Clear the current value of "${label}"?`,
+        confirmLabel: 'Clear value',
+        confirmButtonIntent: 'danger',
+        intent: 'danger',
+        onConfirm: () => handleValueChange(optionName, undefined),
+      });
+    };
     const clearValueButton =
       hasValue && !readOnly && editorLacksOwnClear ?
         <ReqoreButton
@@ -600,12 +612,10 @@ export const CompactRow = memo(
           flat
           minimal
           icon='DeleteBinLine'
+          intent='danger'
           aria-label='Clear value'
           tooltip='Clear value'
-          onClick={(e: React.MouseEvent) => {
-            e.stopPropagation();
-            handleValueChange(optionName, undefined);
-          }}
+          onClick={confirmClearValue}
         />
       : null;
     // Batched commit: a changed row is a draft until Save — mark it with the
@@ -625,15 +635,18 @@ export const CompactRow = memo(
           effect={{ uppercase: true, spaced: 1 }}
         />
       : null;
+    const isPassiveCloseAction = fixedAllowedValueOption || readOnly;
     const closeExpandedFieldButton = (
       <ReqoreButton
         className='options-readfirst-done'
         size='small'
-        intent={!fixedAllowedValueOption && !readOnly ? 'success' : undefined}
+        intent={!isPassiveCloseAction ? 'success' : undefined}
+        flat={isPassiveCloseAction}
+        minimal={isPassiveCloseAction}
         fixed
-        icon={fixedAllowedValueOption || readOnly ? 'CloseLine' : 'CheckLine'}
-        aria-label={fixedAllowedValueOption || readOnly ? 'Close field' : 'Done'}
-        tooltip={fixedAllowedValueOption || readOnly ? 'Close field' : 'Done'}
+        icon={isPassiveCloseAction ? 'CloseLine' : 'CheckLine'}
+        aria-label={isPassiveCloseAction ? 'Close field' : 'Done'}
+        tooltip={isPassiveCloseAction ? 'Close field' : 'Done'}
         onClick={() => toggleExpandedOption(optionName)}
       />
     );
@@ -1035,10 +1048,11 @@ export const CompactRow = memo(
                   minimal
                   flat
                   fixed
+                  intent='danger'
                   className='options-readfirst-clear'
                   aria-label='Clear value'
                   tooltip='Clear value'
-                  onClick={() => handleValueChange(optionName, undefined)}
+                  onClick={confirmClearValue}
                 />
               : null}
               {moreMenu}

--- a/src/components/form/engine/CompactRow.tsx
+++ b/src/components/form/engine/CompactRow.tsx
@@ -96,7 +96,7 @@ const COMPACT_COMPLEX_TYPES = new Set([
 
 // Card editors that hold a SINGLE value through one text-bearing input — their
 // built-in ReqoreInput clear duplicates the card's own "Clear value" action, so
-// we suppress it (the card ✕ is the single source). Structural/multi-input
+// we suppress it (the card trash action is the single source). Structural/multi-input
 // editors (hash, list, schema…) and polymorphic ones (auto/any) are NOT listed:
 // their per-sub-field clears are distinct affordances and must stay, while the
 // card ✕ clears the whole value. (Operators force a card on a scalar value, so
@@ -521,7 +521,11 @@ export const CompactRow = memo(
           />
         </span>
       : null;
-    const editType = ((schema?.ui_type as string) || (schema?.type as string)) ?? '';
+    const fixedAllowedValueOption = isFixedCompactAllowedValueOption(schema);
+    const editType =
+      (fixedAllowedValueOption
+        ? (schema?.type as string) || (schema?.ui_type as string)
+        : (schema?.ui_type as string) || (schema?.type as string)) ?? '';
     // Scalars edit in place inside the row; complex fields (tall or nested
     // editors) still open the expanded card below.
     const inlineEditable =
@@ -595,7 +599,8 @@ export const CompactRow = memo(
           size='small'
           flat
           minimal
-          icon='CloseLine'
+          icon='DeleteBinLine'
+          aria-label='Clear value'
           tooltip='Clear value'
           onClick={(e: React.MouseEvent) => {
             e.stopPropagation();
@@ -620,19 +625,18 @@ export const CompactRow = memo(
           effect={{ uppercase: true, spaced: 1 }}
         />
       : null;
-    const fixedAllowedValueOption = isFixedCompactAllowedValueOption(schema);
-    const closeExpandedFieldButton =
-      fixedAllowedValueOption && !readOnly ?
-        null
-      : <ReqoreButton
-          className='options-readfirst-done'
-          size='small'
-          intent={readOnly ? undefined : 'success'}
-          fixed
-          icon={readOnly ? 'CloseLine' : 'CheckLine'}
-          tooltip={readOnly ? 'Close' : 'Done'}
-          onClick={() => toggleExpandedOption(optionName)}
-        />;
+    const closeExpandedFieldButton = (
+      <ReqoreButton
+        className='options-readfirst-done'
+        size='small'
+        intent={!fixedAllowedValueOption && !readOnly ? 'success' : undefined}
+        fixed
+        icon={fixedAllowedValueOption || readOnly ? 'CloseLine' : 'CheckLine'}
+        aria-label={fixedAllowedValueOption || readOnly ? 'Close field' : 'Done'}
+        tooltip={fixedAllowedValueOption || readOnly ? 'Close field' : 'Done'}
+        onClick={() => toggleExpandedOption(optionName)}
+      />
+    );
 
     // Info tiers: Tier 1 (danger/warning + dependency hints) must be visible
     // without interaction; Tier 2 (info/success, default notes) sits behind ⓘ.
@@ -1027,11 +1031,12 @@ export const CompactRow = memo(
               {hasValue && !readOnly ?
                 <ReqoreButton
                   size='small'
-                  icon='CloseLine'
+                  icon='DeleteBinLine'
                   minimal
                   flat
                   fixed
                   className='options-readfirst-clear'
+                  aria-label='Clear value'
                   tooltip='Clear value'
                   onClick={() => handleValueChange(optionName, undefined)}
                 />

--- a/src/components/form/engine/CompactRow.tsx
+++ b/src/components/form/engine/CompactRow.tsx
@@ -59,6 +59,7 @@ import {
   getHashEntries,
   getReadFirstStatus,
   getValueType,
+  isFixedCompactAllowedValueOption,
   isOptionValueEmpty,
   optionHasImages,
 } from './readFirst';
@@ -619,6 +620,19 @@ export const CompactRow = memo(
           effect={{ uppercase: true, spaced: 1 }}
         />
       : null;
+    const fixedAllowedValueOption = isFixedCompactAllowedValueOption(schema);
+    const closeExpandedFieldButton =
+      fixedAllowedValueOption && !readOnly ?
+        null
+      : <ReqoreButton
+          className='options-readfirst-done'
+          size='small'
+          intent={readOnly ? undefined : 'success'}
+          fixed
+          icon={readOnly ? 'CloseLine' : 'CheckLine'}
+          tooltip={readOnly ? 'Close' : 'Done'}
+          onClick={() => toggleExpandedOption(optionName)}
+        />;
 
     // Info tiers: Tier 1 (danger/warning + dependency hints) must be visible
     // without interaction; Tier 2 (info/success, default notes) sits behind ⓘ.
@@ -860,15 +874,7 @@ export const CompactRow = memo(
                 renderInjectedOptionAction(action, index)
               )}
               {moreMenu}
-              <ReqoreButton
-                className='options-readfirst-done'
-                size='small'
-                intent='success'
-                fixed
-                icon='CheckLine'
-                tooltip='Done'
-                onClick={collapse}
-              />
+              {closeExpandedFieldButton}
             </StyledRowActions>
             {/* Cluster node is rendered LAST (it's absolutely positioned, so DOM
                 order doesn't move it) — keeping it out of the leading cells lets
@@ -1031,15 +1037,7 @@ export const CompactRow = memo(
                 />
               : null}
               {moreMenu}
-              <ReqoreButton
-                size='small'
-                icon={readOnly ? 'CloseLine' : 'CheckLine'}
-                intent='success'
-                fixed
-                className='options-readfirst-done'
-                tooltip={readOnly ? 'Close' : 'Done'}
-                onClick={() => toggleExpandedOption(optionName)}
-              />
+              {closeExpandedFieldButton}
             </ReqoreControlGroup>
           </div>
           {/* Same fullscreen focused-editing affordance as the classic cards —

--- a/src/components/form/engine/FormEngine.stories.tsx
+++ b/src/components/form/engine/FormEngine.stories.tsx
@@ -3398,16 +3398,30 @@ const assertFixedChoiceCanCloseWithoutClearing = async (field: string, expectedL
     { timeout: 10000 }
   );
 
-  await expect(
-    card!.querySelector('.options-readfirst-clear[aria-label="Clear value"]')
-  ).toBeInTheDocument();
-  await expect(
-    card!.querySelector('.options-readfirst-done[aria-label="Close field"]')
-  ).toBeInTheDocument();
-
-  await fireEvent.click(
-    card!.querySelector('.options-readfirst-done[aria-label="Close field"]') as HTMLElement
+  const clearButton = card!.querySelector(
+    '.options-readfirst-clear[aria-label="Clear value"]'
+  ) as HTMLElement;
+  const closeButton = card!.querySelector(
+    '.options-readfirst-done[aria-label="Close field"]'
+  ) as HTMLElement;
+  await expect(clearButton).toBeInTheDocument();
+  await expect(closeButton).toBeInTheDocument();
+  // Clear is destructive and visually distinct from the adjacent passive
+  // actions. It must not mutate the value until the Reqore confirmation is
+  // accepted; cancelling keeps both the value and expanded editor intact.
+  await expect(getComputedStyle(clearButton).color).not.toBe(getComputedStyle(closeButton).color);
+  await fireEvent.click(clearButton);
+  await waitFor(() => expect(document.querySelector('.reqore-confirmation-modal')).toBeTruthy(), {
+    timeout: 10000,
+  });
+  await expect(document.querySelector('.reqore-confirmation-modal')?.textContent).toContain(
+    'Clear value'
   );
+  await _testsClickButton({ label: 'Cancel' });
+  await waitFor(() => expect(document.querySelector('.reqore-confirmation-modal')).toBeNull());
+  await expect(document.querySelector(cardSelector)).toBeTruthy();
+
+  await fireEvent.click(closeButton);
   await waitFor(() => expect(document.querySelector(cardSelector)).toBeNull(), {
     timeout: 10000,
   });
@@ -4226,8 +4240,28 @@ export const CompactFieldTypesEditing: Story = {
       editRow('enabled').querySelector('.options-readfirst-revert')
     ).not.toBeInTheDocument();
 
-    // Clear it → the value empties, so Clear is replaced by Revert in place.
+    // Clear is destructive: cancelling its Reqore confirmation leaves the
+    // value untouched, while confirming empties it and swaps Clear for Revert.
     await fireEvent.click(editRow('enabled').querySelector('.options-readfirst-clear')!);
+    await waitFor(() => expect(document.querySelector('.reqore-confirmation-modal')).toBeTruthy(), {
+      timeout: 10000,
+    });
+    await _testsClickButton({ label: 'Cancel' });
+    await waitFor(() => expect(document.querySelector('.reqore-confirmation-modal')).toBeNull());
+    await expect(editRow('enabled').querySelector('.options-readfirst-clear')).toBeInTheDocument();
+
+    await fireEvent.click(editRow('enabled').querySelector('.options-readfirst-clear')!);
+    let confirmationModal: HTMLElement | null = null;
+    await waitFor(
+      () => {
+        confirmationModal = document.querySelector('.reqore-confirmation-modal');
+        expect(confirmationModal).toBeTruthy();
+      },
+      { timeout: 10000 }
+    );
+    await userEvent.click(
+      within(confirmationModal!).getByRole('button', { name: 'Clear value' })
+    );
     await waitFor(() => {
       expect(editRow('enabled').querySelector('.options-readfirst-clear')).not.toBeInTheDocument();
       expect(editRow('enabled').querySelector('.options-readfirst-revert')).toBeInTheDocument();

--- a/src/components/form/engine/FormEngine.stories.tsx
+++ b/src/components/form/engine/FormEngine.stories.tsx
@@ -5,6 +5,7 @@ import { Meta, StoryObj } from '@storybook/react-vite';
 import { ChangeEvent, useState } from 'react';
 import { expect, fireEvent, fn, userEvent, waitFor, within } from 'storybook/test';
 import { validateField } from '../../../helpers/validations';
+import { defaultQorusTypes } from '../../../hooks/useQorusTypes';
 import {
   _testsChangeRichText,
   _testsChangeStringField,
@@ -90,6 +91,29 @@ const meta: Meta<typeof FormEngine> = {
     chromatic: {
       viewports: [2560],
     },
+    // `useQorusTypes` resolves the type catalogue as `size(data) ? data : defaultQorusTypes`,
+    // so a reachable, authenticated instance *replaces* the built-in list rather than
+    // supplementing it. These stories never opt into live data (no `live: true`), but the
+    // request fires anyway — which made `Option With Any Type` pass locally (401 → built-in
+    // list, so "Boolean" exists) and fail in CI, where the token is valid and the server's
+    // list decides the labels. Pin the catalogue so the type names the plays click are ours.
+    mockData: [
+      {
+        // `query()` builds `${instance}api/latest/${url}`, and the hook's url is
+        // `/system/qorus-type-info` — hence the doubled slash. Both spellings are listed
+        // so the mock keeps matching if that leading slash is ever dropped.
+        url: 'https://hq.qoretechnologies.com:8092/api/latest//system/qorus-type-info',
+        method: 'GET',
+        status: 200,
+        response: defaultQorusTypes,
+      },
+      {
+        url: 'https://hq.qoretechnologies.com:8092/api/latest/system/qorus-type-info',
+        method: 'GET',
+        status: 200,
+        response: defaultQorusTypes,
+      },
+    ],
   },
   render: ({ value, onChange, ...rest }: IFormEngineProps) => {
     const [val, setValue] = useState(value);

--- a/src/components/form/engine/FormEngine.stories.tsx
+++ b/src/components/form/engine/FormEngine.stories.tsx
@@ -622,7 +622,7 @@ export const OptionWithAnyType: Story = {
     // and switch it to a specific custom type (Boolean).
     await _testsOpenTemplateMenu(4);
     await _testsClickButton({ label: 'Set Custom Value' });
-    await _testsClickButton({ label: 'True or False' });
+    await _testsClickButton({ label: 'Boolean' });
   },
 };
 
@@ -3361,6 +3361,43 @@ const langImg = (color: string, letter: string): string =>
     `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32"><rect width="32" height="32" rx="6" fill="${color}"/><text x="16" y="23" font-size="20" fill="white" text-anchor="middle" font-family="sans-serif">${letter}</text></svg>`
   )}`;
 
+const assertFixedChoiceCanCloseWithoutClearing = async (field: string, expectedLabel: string) => {
+  const cardSelector = `.options-readfirst-card[data-field="${field}"]`;
+  const rowSelector = `.readfirst-row[data-field="${field}"]`;
+
+  let card: HTMLElement | null = null;
+  await waitFor(
+    () => {
+      card = document.querySelector(cardSelector);
+      expect(card).toBeTruthy();
+    },
+    { timeout: 10000 }
+  );
+
+  await expect(
+    card!.querySelector('.options-readfirst-clear[aria-label="Clear value"]')
+  ).toBeInTheDocument();
+  await expect(
+    card!.querySelector('.options-readfirst-done[aria-label="Close field"]')
+  ).toBeInTheDocument();
+
+  await fireEvent.click(
+    card!.querySelector('.options-readfirst-done[aria-label="Close field"]') as HTMLElement
+  );
+  await waitFor(() => expect(document.querySelector(cardSelector)).toBeNull(), {
+    timeout: 10000,
+  });
+
+  const row = document.querySelector(rowSelector) as HTMLElement;
+  expect(row?.textContent).toContain(expectedLabel);
+
+  // Re-open so the story's visual snapshot still covers the expanded fixed-choice card.
+  await fireEvent.click(row);
+  await waitFor(() => expect(document.querySelector(cardSelector)).toBeTruthy(), {
+    timeout: 10000,
+  });
+};
+
 /**
  * Enum field with per-value images (the IDE `language` field shape: `type:
  * 'enum'` + `items: [{ value, title, image }]`). Read-first shows the selected
@@ -3426,6 +3463,7 @@ export const CompactEnumWithImages: Story = {
       },
       { timeout: 10000 }
     );
+    await assertFixedChoiceCanCloseWithoutClearing('lang', 'Qore');
   },
 };
 
@@ -3502,6 +3540,7 @@ export const CompactEnumRichtextValue: Story = {
       },
       { timeout: 10000 }
     );
+    await assertFixedChoiceCanCloseWithoutClearing('lang', 'Qore');
   },
 };
 

--- a/src/components/form/engine/FormEngine.tsx
+++ b/src/components/form/engine/FormEngine.tsx
@@ -1935,7 +1935,7 @@ export const FormEngine = ({
         (optionSchema?.type as TQorusType) ||
         'any';
       const effectiveForceDropdown =
-        forceDropdown ||
+        forceDropdown ??
         (templateFieldProps as { forceDropdown?: boolean } | undefined)?.forceDropdown;
 
       return (

--- a/src/components/form/engine/FormEngine.tsx
+++ b/src/components/form/engine/FormEngine.tsx
@@ -101,7 +101,8 @@ import {
   getReadFirstCompletion,
   getReadFirstStatus,
   isOptionValueEmpty,
-  shouldAutoCollapseCompactAllowedValueOption,
+  isFixedCompactAllowedValueOption,
+  shouldAutoCollapseCompactOption,
 } from './readFirst';
 
 // Re-export types for consumers
@@ -282,7 +283,9 @@ const getOptionSchemaStorageType = (
   option?: TQorusFormFieldSchema,
   isRendererOnly: TRendererOnlyCheck = isRendererOnlyUiType
 ): TQorusType =>
-  ((isRendererOnly(option?.ui_type)
+  ((isFixedCompactAllowedValueOption(option)
+    ? option?.type || option?.ui_type
+    : isRendererOnly(option?.ui_type)
     ? option?.type || option?.ui_type
     : option?.ui_type || option?.type) || 'any') as TQorusType;
 
@@ -556,6 +559,11 @@ export interface IFormEngineProps extends Omit<IReqoreCollectionProps, 'onChange
   /** Opt-in: fetch global templates from `system/getContextData` for this context. */
   interfaceContext?: string;
   templateFieldProps?: Partial<ITemplateFieldProps>;
+  /**
+   * Force single-value selectors to use inline dropdowns even when their
+   * allowed values carry descriptions.
+   */
+  forceDropdown?: boolean;
   showTypeToggle?: boolean;
   /**
    * Compact (read-first) mode: each option renders as a row with its formatted
@@ -707,6 +715,7 @@ export const FormEngine = ({
   allowTemplates = true,
   interfaceContext,
   templateFieldProps,
+  forceDropdown,
   showTypeToggle = true,
   compact,
   compactFlush = false,
@@ -836,9 +845,12 @@ export const FormEngine = ({
       // same tick targets the stale (pre-move) layout, so the page doesn't budge.
       // A rAF lets the new position settle first.
       requestAnimationFrame(() => {
-        document
-          .querySelector(`.readfirst-row[data-field="${optionNames[0]}"]`)
-          ?.scrollIntoView({ block: 'center', behavior: 'smooth' });
+        const target = document.querySelector<HTMLElement>(
+          `.readfirst-row[data-field="${optionNames[0]}"]`
+        );
+        if (typeof target?.scrollIntoView === 'function') {
+          target.scrollIntoView({ block: 'center', behavior: 'smooth' });
+        }
       });
     }
     setFlashedOptions(optionNames);
@@ -1161,7 +1173,7 @@ export const FormEngine = ({
         if (
           compact &&
           !readOnly &&
-          shouldAutoCollapseCompactAllowedValueOption(options?.[optionName], val)
+          shouldAutoCollapseCompactOption(options?.[optionName], val)
         ) {
           setExpandedOptions((prev) => prev.filter((name) => name !== optionName));
         }
@@ -1909,14 +1921,23 @@ export const FormEngine = ({
       //
       // The trailing fallbacks keep the row rendering when a server-driven
       // schema has not arrived yet (`type` undefined) instead of crashing.
-      const schemaUiType = options?.[optionName]?.ui_type as TQorusType;
+      const optionSchema = options?.[optionName];
+      const schemaUiType = optionSchema?.ui_type as TQorusType;
       const uiTypeIsAnyLike = schemaUiType === 'any' || schemaUiType === 'auto';
       const resolvedType =
-        (schemaUiType && !uiTypeIsAnyLike ? schemaUiType : undefined) ||
+        (isFixedCompactAllowedValueOption(optionSchema)
+          ? getOptionSchemaStorageType(optionSchema, isRendererOnly)
+          : schemaUiType && !uiTypeIsAnyLike
+            ? schemaUiType
+            : undefined) ||
         type ||
         schemaUiType ||
-        (options?.[optionName]?.type as TQorusType) ||
+        (optionSchema?.type as TQorusType) ||
         'any';
+      const effectiveForceDropdown =
+        forceDropdown ||
+        (templateFieldProps as { forceDropdown?: boolean } | undefined)?.forceDropdown;
+
       return (
         <>
           {(() => {
@@ -2057,8 +2078,16 @@ export const FormEngine = ({
             // reqraft: form-level expression fields get the Visual/Text shell
             // (DPQL text mode); opt out per-form via `templateFieldProps`.
             allowTextExpressions
+            // A fixed allowed-value field still needs its selector even when
+            // arbitrary custom values are forbidden. TemplateField uses this
+            // flag to decide whether to mount AutoFormField at all; treating
+            // `supports_custom_values: false` as "no input" left dependent
+            // delivery fields (Discord server/channel, for example) as empty
+            // control groups. The allowed-values renderer itself enforces the
+            // fixed catalogue and never exposes free-form entry.
             allowCustomValues={
-              options?.[optionName]?.supports_custom_values !== false && resolvedType !== 'any'
+              isFixedCompactAllowedValueOption(optionSchema) ||
+              (options?.[optionName]?.supports_custom_values !== false && resolvedType !== 'any')
             }
             templates={templates.value}
             {...getTypeAndCanBeNull(
@@ -2088,6 +2117,7 @@ export const FormEngine = ({
             default_value={getDefaultValue(options?.[optionName])}
             isDefaultTemplate={options?.[optionName]?.default_view === 'template'}
             allowed_values={options?.[optionName]?.allowed_values}
+            allowed_values_creatable={options?.[optionName]?.allowed_values_creatable}
             disabled={
               options?.[optionName]?.disabled ||
               readOnly ||
@@ -2105,6 +2135,7 @@ export const FormEngine = ({
               : undefined
             }
             {...templateFieldProps}
+            forceDropdown={effectiveForceDropdown}
           />
           <OptionFieldMessages
             schema={options || {}}
@@ -2148,6 +2179,7 @@ export const FormEngine = ({
       uniqueName,
       componentOverrides,
       templateFieldProps,
+      forceDropdown,
       availableOptions,
       fixedValue,
       // Depend on the specific `rest` values used, not the whole `rest` object

--- a/src/components/form/engine/compactRowStyles.ts
+++ b/src/components/form/engine/compactRowStyles.ts
@@ -220,7 +220,8 @@ export const StyledEditCard = styled.div<{ $bg: string; $border: string }>`
 
   /* Single-value editors (operators, long-string, markdown, richtext, byte-size)
      carry the card's own "Clear value" action, so suppress the value input's
-     built-in ReqoreInput clear — ReqoreInput has no prop to hide it, and two ✕
+     built-in ReqoreInput clear — ReqoreInput has no prop to hide it, and a
+     separate input ✕ plus the row-level trash action
      read as a duplicate. Multi-input cards (hash/list/…) are not marked single,
      so their per-sub-field clears stay. */
   &.options-readfirst-card-single .reqore-clear-input-button {

--- a/src/components/form/engine/readFirst.ts
+++ b/src/components/form/engine/readFirst.ts
@@ -87,11 +87,10 @@ export const isOptionValueEmpty = (value: unknown): boolean =>
   value === '' ||
   (Array.isArray(value) && value.length === 0);
 
-export const shouldAutoCollapseCompactAllowedValueOption = (
-  schema: TQorusFormFieldSchema | undefined,
-  value: unknown
+export const isFixedCompactAllowedValueOption = (
+  schema: TQorusFormFieldSchema | undefined
 ): boolean => {
-  if (!schema || isOptionValueEmpty(value)) {
+  if (!schema) {
     return false;
   }
 
@@ -107,6 +106,11 @@ export const shouldAutoCollapseCompactAllowedValueOption = (
     !schema.arg_schema
   );
 };
+
+export const shouldAutoCollapseCompactAllowedValueOption = (
+  schema: TQorusFormFieldSchema | undefined,
+  value: unknown
+): boolean => !isOptionValueEmpty(value) && isFixedCompactAllowedValueOption(schema);
 
 /** Prefer the matching allowed_values entry's display_name (fallback `name`)
  * over the raw stored value. */

--- a/src/components/form/engine/readFirst.ts
+++ b/src/components/form/engine/readFirst.ts
@@ -112,6 +112,23 @@ export const shouldAutoCollapseCompactAllowedValueOption = (
   value: unknown
 ): boolean => !isOptionValueEmpty(value) && isFixedCompactAllowedValueOption(schema);
 
+/** Boolean fields have three meaningful states: unset, Yes, and No. Once the
+ * user chooses either boolean value in compact mode, the choice is complete
+ * and the inline editor can close without a separate confirmation. */
+export const isCompactBooleanOption = (
+  schema: TQorusFormFieldSchema | undefined
+): boolean => {
+  const type = (schema?.ui_type || schema?.type)?.toLowerCase();
+  return type === 'bool' || type === 'boolean';
+};
+
+export const shouldAutoCollapseCompactOption = (
+  schema: TQorusFormFieldSchema | undefined,
+  value: unknown
+): boolean =>
+  !isOptionValueEmpty(value) &&
+  (isCompactBooleanOption(schema) || isFixedCompactAllowedValueOption(schema));
+
 /** Prefer the matching allowed_values entry's display_name (fallback `name`)
  * over the raw stored value. */
 const findAllowedOption = (value: unknown, schema?: TQorusFormFieldSchema): any | undefined => {

--- a/src/components/form/expressions/ExpressionField.stories.tsx
+++ b/src/components/form/expressions/ExpressionField.stories.tsx
@@ -23,6 +23,16 @@ const SAMPLE: IExpression = {
 const meta = {
   component: ExpressionField,
   title: 'Components/Form/Expressions/ExpressionField',
+  parameters: {
+    mockData: [
+      {
+        url: 'https://hq.qoretechnologies.com:8092/api/latest/system?action=expressions&context=ui',
+        method: 'GET',
+        status: 200,
+        response: mockExpressions,
+      },
+    ],
+  },
   args: {
     onChange: fn(),
     expressions: mockExpressions,

--- a/src/components/form/expressions/builder/ExpressionBuilder.stories.tsx
+++ b/src/components/form/expressions/builder/ExpressionBuilder.stories.tsx
@@ -16,7 +16,8 @@ import { ExpressionBuilder } from './index';
 // --- inlined test helpers (equivalents of the IDE `../Tests/utils`) ---------
 
 /** Count regular expression cards (`.expression`). */
-const expressionCount = () => document.querySelectorAll('.expression').length;
+const expressionCount = (scope: ParentNode = document) =>
+  scope.querySelectorAll('.expression').length;
 
 /** Click a ReqoreButton by visible label (anywhere in the document). */
 const clickButtonByLabel = async (label: string) => {
@@ -26,14 +27,14 @@ const clickButtonByLabel = async (label: string) => {
 };
 
 /** Click a button by CSS selector. */
-const clickSelector = async (selector: string, nth = 0) => {
-  const els = document.querySelectorAll(selector);
+const clickSelector = async (selector: string, nth = 0, scope: ParentNode = document) => {
+  const els = scope.querySelectorAll(selector);
   await fireEvent.click(els[nth]);
 };
 
 /** Wait for some text to appear in the document. */
-const waitForText = async (text: string | RegExp) => {
-  const body = within(document.body);
+const waitForText = async (text: string | RegExp, scope: HTMLElement = document.body) => {
+  const body = within(scope);
   await waitFor(() => expect(body.queryAllByText(text)[0]).toBeTruthy(), { timeout: 10000 });
 };
 
@@ -44,15 +45,19 @@ const waitForText = async (text: string | RegExp) => {
  * toolkit `Select` opens a `SelectFieldCollection` modal (not an inline
  * dropdown) — the item is a collection button with the display name as text.
  */
-const selectOperation = async (currentLabel: string, itemLabel: string) => {
-  const body = within(document.body);
+const selectOperation = async (
+  currentLabel: string,
+  itemLabel: string,
+  ownerDocument: Document = document
+) => {
+  const body = within(ownerDocument.body);
   // Open the picker (placeholder when empty, or the current operation name).
   const trigger = await body.findByText(currentLabel, undefined, { timeout: 10000 });
   await fireEvent.click(trigger);
   // Click the item inside the now-open collection modal.
   const item = await waitFor(
     () => {
-      const el = within(document.body).queryAllByText(itemLabel)[0];
+      const el = within(ownerDocument.body).queryAllByText(itemLabel)[0];
       if (!el) throw new Error(`collection item "${itemLabel}" not ready`);
       return el;
     },
@@ -121,8 +126,8 @@ export const Default: Story = {
       },
     },
   },
-  play: async () => {
-    await waitFor(() => expect(expressionCount()).toBe(1), { timeout: 10000 });
+  play: async ({ canvasElement }) => {
+    await waitFor(() => expect(expressionCount(canvasElement)).toBe(1), { timeout: 10000 });
   },
 };
 
@@ -630,19 +635,19 @@ export const ExpressionCanBeWrapped: Story = {
       },
     },
   },
-  play: async () => {
+  play: async ({ canvasElement }) => {
     // Seeded base op + its operand render.
-    await waitFor(() => expect(expressionCount()).toBe(1), { timeout: 10000 });
-    await waitForText('Value To Convert');
+    await waitFor(() => expect(expressionCount(canvasElement)).toBe(1), { timeout: 10000 });
+    await waitForText('Value To Convert', canvasElement);
 
     // Hover the card to reveal the floating "Wrap" picker, then wrap it in
     // `Join List Elements` — the wrapped op becomes its first operand and the
     // outer card shows "List To Join". The card count goes 1 → 2.
-    await userEvent.hover(document.querySelectorAll('.expression')[0]);
+    await userEvent.hover(canvasElement.querySelectorAll('.expression')[0]);
     await sleep(500);
-    await selectOperation('Wrap', 'Join List Elements');
-    await waitForText('List To Join');
-    await waitFor(() => expect(expressionCount()).toBe(2), { timeout: 10000 });
+    await selectOperation('Wrap', 'Join List Elements', canvasElement.ownerDocument);
+    await waitForText('List To Join', canvasElement);
+    await waitFor(() => expect(expressionCount(canvasElement)).toBe(2), { timeout: 10000 });
   },
 };
 
@@ -662,11 +667,13 @@ export const ExpressionCanBeUnwrapped: Story = {
     await ExpressionCanBeWrapped.play!(args);
 
     // Unwrap the outer op (keep the child) — the `.expression-unwrap` action.
-    await userEvent.hover(document.querySelectorAll('.expression')[0]);
+    await userEvent.hover(args.canvasElement.querySelectorAll('.expression')[0]);
     await sleep(500);
+    // The card's actions are ReQore *floating* actions, so they are portalled out
+    // of the canvas — this one lookup stays document-scoped on purpose.
     await clickSelector('.expression-unwrap');
 
-    await waitFor(() => expect(expressionCount()).toBe(1), { timeout: 10000 });
+    await waitFor(() => expect(expressionCount(args.canvasElement)).toBe(1), { timeout: 10000 });
   },
 };
 

--- a/src/components/form/expressions/builder/index.tsx
+++ b/src/components/form/expressions/builder/index.tsx
@@ -651,7 +651,10 @@ export const Expression = ({
     return value.value?.args?.some((arg) => arg?.types_mismatch);
   }, [JSON.stringify(value)]);
 
-  if (expressions.loading || types.loading) {
+  // The type hook is seeded with the complete built-in catalogue and refreshes
+  // it in the background.  Do not hide an otherwise usable expression behind
+  // a skeleton while that optional refresh is in flight.
+  if (expressions.loading || (types.loading && !size(types.value))) {
     return <ReqorePanelSkeleton size='small' />;
   }
 
@@ -687,6 +690,11 @@ export const Expression = ({
           fluid={false}
           fixed={true}
           flat
+          // The operation catalogue is long and every entry carries a description,
+          // so it belongs in the searchable collection modal rather than an inline
+          // dropdown. `SelectFormField` defaults `forceDropdown` to `true`, which
+          // would otherwise collapse this picker into the dropdown presentation.
+          forceDropdown={false}
           minimal
           items={defaultItems}
           onChange={handleOperatorChange}
@@ -732,6 +740,9 @@ export const Expression = ({
             transparent: false,
             fixed: true,
             minimal: false,
+            // Same catalogue as the operation selector above — keep the collection
+            // modal rather than the `forceDropdown` default's inline dropdown.
+            forceDropdown: false,
             items: defaultItems,
             hideItemCount: true,
             onChange: handleWrapExpressionClick,

--- a/src/components/form/expressions/useExpressions.ts
+++ b/src/components/form/expressions/useExpressions.ts
@@ -84,7 +84,10 @@ export const useExpressions = (
 
   return {
     expressions,
-    loading: system.loading || extra.loading,
+    // `extra` is deliberately not loaded without an expressions URL.  The
+    // generic fetch hook keeps an unstarted request in its initial loading
+    // state, so only include it when that request is actually enabled.
+    loading: system.loading || (!!expressionsUrl && extra.loading),
     error: errorOverride ?? system.error ?? extra.error,
     reload: () => {
       system.load();

--- a/src/components/form/fields/Field.tsx
+++ b/src/components/form/fields/Field.tsx
@@ -540,7 +540,7 @@ export const FormField = <T extends TFormFieldType>({
           fluid
           hideItemCount
           forceDropdown={
-            (fieldProps as { forceDropdown?: boolean } | undefined)?.forceDropdown ||
+            (fieldProps as { forceDropdown?: boolean } | undefined)?.forceDropdown ??
             (rest as { forceDropdown?: boolean }).forceDropdown
           }
         />
@@ -584,7 +584,7 @@ export const FormField = <T extends TFormFieldType>({
         onChange={(val) => handleChange(val as TFormFieldValueType<T>)}
         fluid
         forceDropdown={
-          (fieldProps as { forceDropdown?: boolean } | undefined)?.forceDropdown ||
+          (fieldProps as { forceDropdown?: boolean } | undefined)?.forceDropdown ??
           (rest as { forceDropdown?: boolean }).forceDropdown
         }
       />

--- a/src/components/form/fields/Field.tsx
+++ b/src/components/form/fields/Field.tsx
@@ -25,6 +25,7 @@ import NumberFormField from './number/Number';
 import { ReqraftObjectFormField } from './object/Object';
 import { RichTextFormField } from './rich-text/RichText';
 import { SelectFormField } from './select/Select';
+import { getSelectItemShortDescription } from './select/SelectCollection';
 import { StringFormField } from './string/String';
 import { ArrayAutoField } from './array/ArrayAutoField';
 import { AutoFormField } from './auto/AutoFormField';
@@ -538,6 +539,10 @@ export const FormField = <T extends TFormFieldType>({
           icon='SaveFill'
           fluid
           hideItemCount
+          forceDropdown={
+            (fieldProps as { forceDropdown?: boolean } | undefined)?.forceDropdown ||
+            (rest as { forceDropdown?: boolean }).forceDropdown
+          }
         />
       );
     }
@@ -557,7 +562,7 @@ export const FormField = <T extends TFormFieldType>({
                 margin='right'
                 key={index}
                 label={item.display_name ?? JSON.stringify(itemValue)}
-                tooltip={item.short_desc || item.desc}
+                tooltip={getSelectItemShortDescription(mapAllowedValue(item))}
                 disabled={item.disabled}
                 checked={checked}
                 intent={checked ? 'info' : undefined}
@@ -578,6 +583,10 @@ export const FormField = <T extends TFormFieldType>({
         value={value}
         onChange={(val) => handleChange(val as TFormFieldValueType<T>)}
         fluid
+        forceDropdown={
+          (fieldProps as { forceDropdown?: boolean } | undefined)?.forceDropdown ||
+          (rest as { forceDropdown?: boolean }).forceDropdown
+        }
       />
     );
   };

--- a/src/components/form/fields/allowed-values/AllowedValues.tsx
+++ b/src/components/form/fields/allowed-values/AllowedValues.tsx
@@ -12,8 +12,8 @@ import { ReqoreCheckbox, ReqoreControlGroup, ReqoreSpan } from '@qoretechnologie
 import { IReqoreButtonProps } from '@qoretechnologies/reqore/dist/components/Button';
 import { IQorusAllowedValue, TQorusType } from '@qoretechnologies/ts-toolkit';
 import { size as count, isEqual } from 'lodash';
-import { memo, useCallback, useEffect, useMemo, useState } from 'react';
-import { useDebounce } from 'react-use';
+import { memo, useMemo } from 'react';
+import { getSelectItemShortDescription } from '../select/SelectCollection';
 import { ISelectFormFieldItem, SelectFormField as Select } from '../select/Select';
 
 export interface IFieldAllowedValuesProps extends Pick<
@@ -30,6 +30,7 @@ export interface IFieldAllowedValuesProps extends Pick<
   app?: string;
   action?: string;
   showSavedValues?: boolean;
+  forceDropdown?: boolean;
   [key: string]: any;
 }
 
@@ -57,7 +58,7 @@ export const FieldAllowedValuesCheckGroup = memo(
             margin='right'
             key={item.value?.toString()}
             label={item.display_name || JSON.stringify(item.value)}
-            tooltip={item.short_desc || item.desc}
+            tooltip={getSelectItemShortDescription(item)}
             disabled={rest.disabled}
             readOnly={rest.readOnly}
             intent={item.value === value ? 'info' : undefined}
@@ -97,49 +98,23 @@ export const FieldAllowedValues = memo(
     allowCreation,
     showSavedValues,
     showDescription,
+    forceDropdown,
     size,
     disabled,
     name,
     readOnly,
   }: IFieldAllowedValuesProps) => {
-    const [localValue, setLocalValue] = useState(value);
-    const [localItems, setLocalItems] = useState<IQorusAllowedValue[]>(items);
-
-    useEffect(() => {
-      setLocalItems(items);
-    }, [JSON.stringify(items)]);
-
-    const handleLocalChange = useCallback((_name: string, value: unknown) => {
-      setLocalValue(value);
-    }, []);
-
-    useDebounce(
-      () => {
-        if (localValue !== value) {
-          onChange(name, localValue);
-        }
-      },
-      200,
-      [localValue]
-    );
-
-    useEffect(() => {
-      if (value !== localValue) {
-        setLocalValue(value);
-      }
-    }, [value]);
-
     const fullItems = useMemo(() => {
       const result = [
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        ...localItems.map(({ metadata, value, ...rest }) => ({
+        ...items.map(({ metadata, value, ...rest }) => ({
           value: value?.value,
           ...rest,
         })),
       ] as ISelectFormFieldItem[];
 
       return result;
-    }, [JSON.stringify(localItems), type, value, showSavedValues, disabled, readOnly]);
+    }, [JSON.stringify(items), type, value, showSavedValues, disabled, readOnly]);
 
     const style = useMemo(() => ({ width: '100%' }), []);
 
@@ -153,8 +128,8 @@ export const FieldAllowedValues = memo(
         return (
           <FieldAllowedValuesCheckGroup
             items={fullItems}
-            onChange={handleLocalChange}
-            value={localValue}
+            onChange={onChange}
+            value={value}
             name={name}
           />
         );
@@ -164,10 +139,11 @@ export const FieldAllowedValues = memo(
         <Select
           items={fullItems}
           value={value}
-          onChange={(value) => handleLocalChange(name, value)}
+          onChange={(value) => onChange(name, value)}
           fluid
           fixed={false}
           showDescription={Boolean(showDescription || showDescription === undefined)}
+          forceDropdown={forceDropdown}
           style={style}
           size={size}
           disabled={disabled}
@@ -178,10 +154,11 @@ export const FieldAllowedValues = memo(
     return (
       <Select
         items={fullItems}
-        onChange={(value) => handleLocalChange(name, value)}
+        onChange={(value) => onChange(name, value)}
         fluid
         fixed={false}
         showDescription={false}
+        forceDropdown={forceDropdown}
         style={style}
         minimal
         placeholder={'Saved & Suggested Values'}

--- a/src/components/form/fields/auto/AutoFormField.stories.tsx
+++ b/src/components/form/fields/auto/AutoFormField.stories.tsx
@@ -330,6 +330,7 @@ export const RichText: Story = {
 export const ConnectionWithAllowedValues: Story = {
   args: {
     defaultType: 'connection',
+    forceDropdown: false,
     allowed_values: [
       {
         display_name: 'test',

--- a/src/components/form/fields/auto/AutoFormField.tsx
+++ b/src/components/form/fields/auto/AutoFormField.tsx
@@ -374,6 +374,7 @@ function AutoField<T = any>({
   ) {
     return (
       <SchemaDefinitionEditor
+        {...((rest as any).fieldProps || {})}
         value={
           value === null || value === undefined
             ? undefined

--- a/src/components/form/fields/auto/AutoFormField.tsx
+++ b/src/components/form/fields/auto/AutoFormField.tsx
@@ -419,6 +419,7 @@ function AutoField<T = any>({
         app={rest.app}
         action={rest.action}
         showDescription={rest.showDescription}
+        forceDropdown={rest.forceDropdown}
         allowCreation={rest.allowed_values_creatable}
         showSavedValues={showSavedValues}
         readOnly={rest.readonly}

--- a/src/components/form/fields/boolean/Boolean.stories.tsx
+++ b/src/components/form/fields/boolean/Boolean.stories.tsx
@@ -75,6 +75,40 @@ export const Unchecked: Story = {
   },
 };
 
+export const Unset: Story = {
+  args: {
+    checked: undefined,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders the Boolean field without a default choice. The switch remains visibly unset until the user explicitly chooses Yes or No.',
+      },
+    },
+  },
+};
+
+export const UnsetSelectsYes: Story = {
+  args: {
+    checked: undefined,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Verifies that an unset Boolean field saves the first explicit Yes selection instead of treating the missing value as No.',
+      },
+    },
+  },
+  async play({ canvasElement, args }) {
+    const canvas = within(canvasElement);
+
+    await userEvent.click(canvas.getByLabelText('Boolean'));
+    await expect(args.onChange).toHaveBeenLastCalledWith(true);
+  },
+};
+
 export const Disabled: Story = {
   args: {
     checked: true,

--- a/src/components/form/fields/boolean/Boolean.tsx
+++ b/src/components/form/fields/boolean/Boolean.tsx
@@ -18,7 +18,7 @@ export const BooleanFormField = ({
 
   return (
     <ReqoreCheckbox
-      checked={checked ?? false}
+      checked={checked}
       onClick={toggle}
       asSwitch
       onText='Yes'

--- a/src/components/form/fields/multi-select/MultiSelectFormField.tsx
+++ b/src/components/form/fields/multi-select/MultiSelectFormField.tsx
@@ -2,6 +2,7 @@ import { ReqoreMultiSelect } from '@qoretechnologies/reqore';
 import { TReqoreMultiSelectItem } from '@qoretechnologies/reqore/dist/components/MultiSelect';
 import { IQorusAllowedValue } from '@qoretechnologies/ts-toolkit';
 import { memo, useMemo } from 'react';
+import { getSelectItemShortDescription } from '../select/SelectCollection';
 
 export interface IMultiSelectFormFieldProps {
   /** Currently selected values (plain scalars) */
@@ -33,16 +34,19 @@ export const MultiSelectFormField = memo(
 
     const reqoreItems = useMemo<TReqoreMultiSelectItem[]>(() => {
       const base = items.map(
-        (item): TReqoreMultiSelectItem => ({
-          value: item.value?.value as string,
-          label: item.display_name ?? String(item.value?.value ?? ''),
-          description: item.short_desc || item.desc,
-          tooltip: item.desc || item.short_desc,
-          wrap: true,
-          // IDE parity: when `*` is selected, every other item is disabled.
-          disabled:
-            !!item.disabled || (selectedValues.includes('*') && item.value?.value !== '*'),
-        })
+        (item): TReqoreMultiSelectItem => {
+          const description = getSelectItemShortDescription(item);
+
+          return {
+            value: item.value?.value as string,
+            label: item.display_name ?? String(item.value?.value ?? ''),
+            description,
+            wrap: true,
+            // IDE parity: when `*` is selected, every other item is disabled.
+            disabled:
+              !!item.disabled || (selectedValues.includes('*') && item.value?.value !== '*'),
+          };
+        }
       );
 
       // IDE parity: selected values that aren't in the allowed list still

--- a/src/components/form/fields/select/Select.stories.tsx
+++ b/src/components/form/fields/select/Select.stories.tsx
@@ -62,6 +62,7 @@ export const ItemsWithDescription: Story = {
     },
   },
   args: {
+    forceDropdown: false,
     items: [
       { display_name: 'Item 1', desc: 'This is item 1', value: 'item1', icon: 'MoneyEuroCircleFill', groups: ['Miscellaneous'] },
       { display_name: 'Item 2', desc: 'This is item 2', value: 'item2', image: 'https://avatars.githubusercontent.com/u/8861481?v=4' },
@@ -106,6 +107,7 @@ export const ItemsWithDescriptionAndMessages: Story = {
     },
   },
   args: {
+    forceDropdown: false,
     items: [
       {
         display_name: 'Item 1',
@@ -162,6 +164,7 @@ export const DisabledItemsWithIntent: Story = {
 
 export const DisabledItemsWithIntentAndDescriptions: Story = {
   args: {
+    forceDropdown: false,
     items: [
       { display_name: 'Item 1', desc: 'This is item 1', value: 'item1' },
       { display_name: 'Item 2', short_desc: 'This is item 2', value: 'item2' },
@@ -326,6 +329,7 @@ export const AutoSelectWithDescriptions: Story = {
 
 export const ItemValuesAreObjectsAndCanBeSelected: Story = {
   args: {
+    forceDropdown: false,
     value: { id: { type: 'string', value: 'item1' } },
     items: [
       { value: { id: { type: 'string', value: 'item1' } } },

--- a/src/components/form/fields/select/Select.tsx
+++ b/src/components/form/fields/select/Select.tsx
@@ -235,13 +235,35 @@ export const SelectFormField = memo(
       [size(items), hideItemCount]
     );
 
-    if (autoSelect && filteredItems.length === 1 && !filteredItems[0].disabled) {
-      if (!disabled && !isEqual(filteredItems[0].value, value) && !value) {
-        handleSelectClick(filteredItems[0]);
-      }
+    const autoSelectedItem = useMemo(
+      () =>
+        autoSelect && filteredItems.length === 1 && !filteredItems[0].disabled
+          ? filteredItems[0]
+          : undefined,
+      [autoSelect, filteredItems]
+    );
 
-      const itemHasError = hasError(items, filteredItems[0].value);
-      const itemHasWarning = hasWarning(items, filteredItems[0].value);
+    // Selecting during render causes a parent-controlled field to synchronously
+    // update while this component is still rendering. React rejects that update
+    // and can enter an infinite render loop. Commit the derived default after
+    // rendering instead; the button below already renders the sole item's label
+    // while the controlled value catches up.
+    useEffect(() => {
+      const valueIsUnset = value === undefined || value === null || value === '';
+
+      if (
+        autoSelectedItem &&
+        !disabled &&
+        valueIsUnset &&
+        !isEqual(autoSelectedItem.value, value)
+      ) {
+        handleSelectClick(autoSelectedItem);
+      }
+    }, [autoSelectedItem, disabled, handleSelectClick, value]);
+
+    if (autoSelectedItem) {
+      const itemHasError = hasError(items, autoSelectedItem.value);
+      const itemHasWarning = hasWarning(items, autoSelectedItem.value);
 
       return (
         <ReqoreButton
@@ -252,12 +274,12 @@ export const SelectFormField = memo(
           fluid={fluid}
           flat={flat ?? false}
           size={componentSize}
-          label={getLabel(items, value ?? filteredItems[0].value)}
+          label={getLabel(items, value ?? autoSelectedItem.value)}
           description={getItemShortDescription(value as string) as string}
           readOnly
           fixed
           minimal
-          {...getIcon(filteredItems, filteredItems[0].value)}
+          {...getIcon(filteredItems, autoSelectedItem.value)}
           intent={
             itemHasError ? 'danger'
             : itemHasWarning ?

--- a/src/components/form/fields/select/Select.tsx
+++ b/src/components/form/fields/select/Select.tsx
@@ -11,7 +11,11 @@ import { TReqoreIntent } from '@qoretechnologies/reqore/dist/constants/theme';
 import { IReqoreIconName } from '@qoretechnologies/reqore/dist/types/icons';
 import { isEqual, size } from 'lodash';
 import { memo, useCallback, useEffect, useMemo, useState } from 'react';
-import { ISelectFieldCollectionItem, SelectFieldCollection } from './SelectCollection';
+import {
+  getSelectItemShortDescription,
+  ISelectFieldCollectionItem,
+  SelectFieldCollection,
+} from './SelectCollection';
 
 export type ISelectFormFieldItem = ISelectFieldCollectionItem;
 
@@ -68,7 +72,7 @@ export const SelectFormField = memo(
     showPlaceholder = true,
     showRightIcon = true,
     hideItemCount,
-    forceDropdown,
+    forceDropdown = true,
     fluid,
     flat,
     intent,
@@ -89,6 +93,7 @@ export const SelectFormField = memo(
           return;
         }
         onChange?.(item.value);
+        setCollectionOpen(false);
       },
       [onChange, value]
     );
@@ -96,7 +101,7 @@ export const SelectFormField = memo(
     const getItemDescription = useCallback(
       (itemValue: unknown) => {
         const item = items.find((item) => isEqual(item.value, itemValue));
-        return item?.desc || item?.short_desc;
+        return getSelectItemShortDescription(item);
       },
       [items]
     );
@@ -133,7 +138,7 @@ export const SelectFormField = memo(
         const item = items.find(
           (item) => isEqual(item.display_name, itemName) || isEqual(item.value, itemName)
         );
-        return item?.short_desc || (item?.desc ? 'Hover to see description' : defaultDesc);
+        return getSelectItemShortDescription(item, defaultDesc);
       },
       [items, showDescription]
     );
@@ -291,7 +296,6 @@ export const SelectFormField = memo(
             <SelectFieldCollection
               items={filteredItems}
               filters={filters}
-              getItemDescription={(v) => getItemDescription(v) as string}
               value={value}
               onItemSelect={handleSelectClick}
               onClose={() => setCollectionOpen(false)}

--- a/src/components/form/fields/select/SelectCollection.tsx
+++ b/src/components/form/fields/select/SelectCollection.tsx
@@ -4,7 +4,6 @@ import {
   ReqoreControlGroup,
   ReqoreMessage,
   ReqoreModal,
-  ReqoreP,
 } from '@qoretechnologies/reqore';
 import { IReqoreCollectionItemProps } from '@qoretechnologies/reqore/dist/components/Collection/item';
 import { TReqoreBadge } from '@qoretechnologies/reqore/dist/components/Button';
@@ -12,7 +11,7 @@ import { TReqoreIntent } from '@qoretechnologies/reqore/dist/constants/theme';
 import { IReqoreIconName } from '@qoretechnologies/reqore/dist/types/icons';
 import { capitalize, isEqual, size } from 'lodash';
 import { useMemo, useState } from 'react';
-import ReactMarkdown from 'react-markdown';
+import { Description } from '../../../Description';
 
 const PositiveColorEffect = {
   gradient: {
@@ -25,6 +24,7 @@ const PositiveColorEffect = {
 
 export interface ISelectFieldCollectionItem {
   value?: unknown;
+  name?: unknown;
   display_name?: string;
   desc?: string;
   short_desc?: string;
@@ -42,28 +42,76 @@ export interface ISelectFieldCollectionItem {
 export interface ISelectFieldCollectionProps {
   onClose: () => void;
   items: ISelectFieldCollectionItem[];
-  getItemDescription: (value: unknown) => string;
   value?: unknown;
   onItemSelect: (item: ISelectFieldCollectionItem) => void;
   filters?: string[];
 }
 
+const normalizeSelectItemDescription = (value: unknown): string | undefined => {
+  if (typeof value !== 'string' || !value.trim()) {
+    return undefined;
+  }
+
+  const seen = new Set<string>();
+
+  return value
+    .split('\n')
+    .filter((line) => {
+      const normalized = line.trim().replace(/\s+/g, ' ').toLocaleLowerCase();
+
+      if (!normalized) {
+        return true;
+      }
+
+      if (seen.has(normalized)) {
+        return false;
+      }
+
+      seen.add(normalized);
+      return true;
+    })
+    .join('\n')
+    .trim();
+};
+
 export const getSelectItemDescription = (
   item: Pick<ISelectFieldCollectionItem, 'desc' | 'short_desc'>
 ): string | undefined => {
-  const desc = typeof item.desc === 'string' && item.desc.trim() ? item.desc.trim() : undefined;
-  const shortDesc =
-    typeof item.short_desc === 'string' && item.short_desc.trim()
-      ? item.short_desc.trim()
-      : undefined;
-
+  const desc = normalizeSelectItemDescription(item.desc);
+  const shortDesc = normalizeSelectItemDescription(item.short_desc);
   return desc ?? shortDesc;
+};
+
+export const getSelectItemShortDescription = (
+  item: Pick<ISelectFieldCollectionItem, 'desc' | 'short_desc'> | undefined,
+  defaultDesc = ''
+): string | undefined => {
+  if (!item) {
+    return defaultDesc || undefined;
+  }
+
+  const shortDescription = normalizeSelectItemDescription(item.short_desc);
+
+  return shortDescription || defaultDesc || undefined;
+};
+
+export const getSelectItemDescriptionProps = (
+  item: Pick<ISelectFieldCollectionItem, 'desc' | 'short_desc'>
+): { longDescription?: string; shortDescription?: string } => {
+  const longDescription = normalizeSelectItemDescription(item.desc);
+
+  if (longDescription) {
+    return { longDescription };
+  }
+
+  const shortDescription = normalizeSelectItemDescription(item.short_desc);
+
+  return { shortDescription };
 };
 
 export const SelectFieldCollection = ({
   onClose,
   items,
-  getItemDescription,
   value,
   onItemSelect,
   filters,
@@ -113,7 +161,7 @@ export const SelectFieldCollection = ({
         size='tiny'
         showLayoutSwitch={false}
         items={filteredItems.map((item): IReqoreCollectionItemProps => {
-          const description = getSelectItemDescription(item);
+          const { longDescription, shortDescription } = getSelectItemDescriptionProps(item);
 
           return {
             label: item.display_name || item.value?.toString(),
@@ -123,7 +171,14 @@ export const SelectFieldCollection = ({
             responsiveTitle: false,
             content: (
               <ReqoreControlGroup vertical fluid>
-                {description && <ReqoreP size='small'>{description}</ReqoreP>}
+                {longDescription || shortDescription ? (
+                  <Description
+                    longDescription={longDescription || ''}
+                    shortDescription={shortDescription}
+                    size='small'
+                    margin='none'
+                  />
+                ) : null}
                 {item.actions?.map(({ as: Component = ReqoreButton, props, ...rest }, index) => (
                   <Component
                     key={index}
@@ -161,13 +216,6 @@ export const SelectFieldCollection = ({
               size: '20px',
               rounded: true,
             },
-            tooltip: !!item.desc
-              ? {
-                  delay: 800,
-                  content: <ReactMarkdown>{getItemDescription(item.value)}</ReactMarkdown>,
-                  maxWidth: '70vw',
-                }
-              : undefined,
             onClick: !item.disabled
               ? (e) => {
                   if (e.currentTarget.contains(e.target as Node)) {

--- a/src/components/form/fields/select/SelectCollection.tsx
+++ b/src/components/form/fields/select/SelectCollection.tsx
@@ -48,6 +48,18 @@ export interface ISelectFieldCollectionProps {
   filters?: string[];
 }
 
+export const getSelectItemDescription = (
+  item: Pick<ISelectFieldCollectionItem, 'desc' | 'short_desc'>
+): string | undefined => {
+  const desc = typeof item.desc === 'string' && item.desc.trim() ? item.desc.trim() : undefined;
+  const shortDesc =
+    typeof item.short_desc === 'string' && item.short_desc.trim()
+      ? item.short_desc.trim()
+      : undefined;
+
+  return desc ?? shortDesc;
+};
+
 export const SelectFieldCollection = ({
   onClose,
   items,
@@ -100,8 +112,10 @@ export const SelectFieldCollection = ({
         transparent={false}
         size='tiny'
         showLayoutSwitch={false}
-        items={filteredItems.map(
-          (item): IReqoreCollectionItemProps => ({
+        items={filteredItems.map((item): IReqoreCollectionItemProps => {
+          const description = getSelectItemDescription(item);
+
+          return {
             label: item.display_name || item.value?.toString(),
             size: 'tiny',
             groups: item.groups,
@@ -109,8 +123,7 @@ export const SelectFieldCollection = ({
             responsiveTitle: false,
             content: (
               <ReqoreControlGroup vertical fluid>
-                {item.short_desc && <ReqoreP size='small'>{item.short_desc}</ReqoreP>}
-                {item.desc && <ReqoreP size='small'>{item.desc}</ReqoreP>}
+                {description && <ReqoreP size='small'>{description}</ReqoreP>}
                 {item.actions?.map(({ as: Component = ReqoreButton, props, ...rest }, index) => (
                   <Component
                     key={index}
@@ -163,8 +176,8 @@ export const SelectFieldCollection = ({
                   }
                 }
               : undefined,
-          })
-        )}
+          };
+        })}
         actions={filters?.map((filter) => ({
           label: capitalize(filter.replace('_', ' ')),
           badge: items.filter((item) => item[filter]).length,

--- a/src/stores/currentUser/currentUser.stories.tsx
+++ b/src/stores/currentUser/currentUser.stories.tsx
@@ -6,6 +6,38 @@ import { currentUserStore } from './currentUser';
 
 const meta = {
   title: 'Stores/Current User',
+  parameters: {
+    mockData: [
+      {
+        url: 'https://hq.qoretechnologies.com:8092/api/latest/users?action=current',
+        method: 'GET',
+        status: 200,
+        response: {
+          provider: 'local',
+          username: 'david',
+          name: 'David Nichols',
+          has_default: true,
+          roles: ['admin'],
+          permissions: ['USER-CONTROL'],
+          workflows: [],
+          services: [],
+          jobs: [],
+          mappers: [],
+          vmaps: [],
+          groups: [],
+          fsms: [],
+        },
+      },
+    ],
+  },
+  beforeEach: () => {
+    currentUserStore.setState({
+      currentUser: undefined,
+      loading: false,
+      error: undefined,
+      errorData: undefined,
+    });
+  },
   render: () => {
     const { load, loading, currentUser = {}, errorData } = currentUserStore();
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1384,10 +1384,10 @@
   resolved "https://registry.yarnpkg.com/@qoretechnologies/qlip/-/qlip-0.1.3-beta.20260724071501.tgz#19117eb1737581f3acddc0bc5bda2c7c7dcf1738"
   integrity sha512-SGRDzB1ayO27FvlrJIsUR57ATHntnBDyuW7HaFJ0eTzwLfS9GQwBOich8qA+55gIg6wtrYVKlhq1At89pdQVKA==
 
-"@qoretechnologies/reqore@^0.71.14":
-  version "0.71.14"
-  resolved "https://registry.yarnpkg.com/@qoretechnologies/reqore/-/reqore-0.71.14.tgz#4e5413c82895ccff147d92b33b21d0a74cba2f9d"
-  integrity sha512-9ArHI9RYxBEzAT3HeDB5jYqyD89DqdjbjWqRsIU7sTx/3I1uA84gKIfw6pT76rUe5Fo763yysINdzIUiA89yYg==
+"@qoretechnologies/reqore@^0.71.16":
+  version "0.71.16"
+  resolved "https://registry.yarnpkg.com/@qoretechnologies/reqore/-/reqore-0.71.16.tgz#72e4e595e6e4309ef11b36ad331d95793cac47df"
+  integrity sha512-6s+Ap5iJmLyEbA3jOIvSv9J3KOfQjOJOORXwrmqbnURvAdj9gmw9zvfEwmdwl5TBy1BrOcypBRddLHL9tR9GXA==
   dependencies:
     "@internationalized/date" "^3.5.3"
     "@popperjs/core" "^2.11.6"


### PR DESCRIPTION
## Summary

Completes the fixed-choice compact-form work and fixes the fallout from `SelectFormField` defaulting `forceDropdown` to `true`. Needed by qorus-ide, which currently runs against a local `0.10.20` build.

## What's here

**Fixed-choice completion** (`79d89c1`) — fixed allowed-value compact fields auto-collapse after selection without a redundant Done control, read-only rows keep a Close affordance, and select-collection items render one description (long, falling back to short) instead of repeating equivalent text.

**`forceDropdown` regression.** `SelectFormField` began defaulting `forceDropdown` to `true`. The picker chooses the searchable collection modal on `hasItemsWithDesc(items) && !forceDropdown`, so a `true` default means items with descriptions can never reach the modal again. Two consequences:

- Callers combined the flag with `||` (`forceDropdown || fieldProps.forceDropdown`), which can never yield `false` — an explicit `forceDropdown={false}` was swallowed. Now `??`, so only an *unset* flag falls through.
- The expression builder's two operation pickers, whose catalogue entries all carry descriptions, silently collapsed into inline dropdowns. Both now request the collection modal explicitly.

**Auto-select during render.** `SelectFormField` called `handleSelectClick` during render when `autoSelect` had one candidate, firing the parent's `onChange` mid-render. React rejects that ("Cannot update a component while rendering a different component") and a parent that re-renders on the change can hit "Too many re-renders". The candidate is now derived during render and committed from an effect; the button still shows the item's label while the controlled value catches up, so nothing changes visually.

**Silent bugs found along the way:**

- `useExpressions` reported `loading` from the `extra` request even with no expressions URL. The fetch hook keeps an unstarted request in its initial loading state, so the builder waited forever on a request that never ran.
- The builder hid usable expressions behind a skeleton whenever the type catalogue was refreshing — but that hook is seeded with the full built-in catalogue and only refreshes in the background.
- `AutoFormField` dropped `fieldProps` on the schema-definition branch.
- Expression and current-user stories fetched unmocked endpoints; they now carry `mockData`, and the current-user stories reset the store between runs so they stop leaking state into each other.

## The story failures, and why they were opaque

`ExpressionCanBeWrapped` / `ExpressionCanBeUnwrapped` drive the operation picker through the collection modal, so the `forceDropdown` flip broke them. The reported failure pointed nowhere useful: an unhandled rejection tore the preview down to Storybook's **"No Preview"** screen, so what surfaced was a timed-out `waitForText` rather than the cause. Confirmed by bisecting the tree:

| Tree state | Result |
|---|---|
| `src/components/form` at `origin/develop` | 22 passed |
| At `79d89c1`, no uncommitted work | 2 failed |
| With `forceDropdown={false}` on both pickers | 21 passed, 1 failed |
| Plus document-scoped `.expression-unwrap` | **22 passed** |

The last one is separate: the card's actions are ReQore *floating* actions and are portalled out of the canvas, so scoping that lookup to `canvasElement` could never find them.

## Verification

- `yarn precheck` — 518 tests / 23 files, lint + prod `tsc` clean
- `yarn test:stories` (full suite) — 331 tests / 36 files, all passing

Version bumped to **0.10.20** (develop is at `0.10.19`).

## Dependency alignment

Reqraft now requires **Reqore 0.71.16** in both its development and peer dependency ranges, and the lockfile resolves that exact release. This picks up the merged [Reqore component-prop filtering fix](https://github.com/qoretechnologies/reqore/pull/623) and keeps local, CI, and consumer validation on the same version.


## Qlip review follow-up

- Passive Close actions are now flat and minimal, matching the adjacent overflow control.
- Clear-value trash actions use danger intent and Reqore confirmation with a danger confirm action before mutating the field.
- Story interactions cover cancellation, confirmation, retained fixed-choice values, and the visual intent contrast.

Verified with the three affected FormEngine story interactions, a local Qlip capture, and `yarn precheck` (518 unit tests, lint, and production TypeScript checks).
